### PR TITLE
add clang builds to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,7 @@ cache:
 
 compiler:
   - gcc
+  - clang
 
 notifications:
   branches:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,13 @@ RUN ccache -s
 RUN make test
 RUN make install DESTDIR=${PWD}
 RUN make doxygen
-RUN cd .. && if [ ${COVERAGE} ]; then $HOME/.local/bin/codecov; fi && cd -
+RUN cd .. && if [ ${COVERAGE} ]; then \
+  if [ ${CC} = clang ]; then \
+    $HOME/.local/bin/codecov --gcov-exec "llvm-cov gcov"; \
+  else \
+    $HOME/.local/bin/codecov; \
+  fi; \
+fi && cd -
 USER root
 RUN make install
 USER flecsi


### PR DESCRIPTION
The builds are currently failing due to
- new warnings
- `Exception: Illegal` in tests `task` and `simple_function` for `RUNTIME=serial`.

Just push your fixes on the `clang` branch.