### PR TITLE
Added missing space between command line include paths. 

### DIFF
--- a/tools/flecsit/flecsit/services/service_utils.py
+++ b/tools/flecsit/flecsit/services/service_utils.py
@@ -113,7 +113,7 @@ def generate_compiler_options(config, paths, environment, option):
     else:
         if paths:
             for path in paths or []:
-                options += option + path + ''
+                options += option + path + ' '
 
     return options.strip()
 


### PR DESCRIPTION
Currently generates -I/path/-I/path2/ 
Fixing to -I/path/ -I/path2/