### PR TITLE
New feature: Design By Contract assertions

### DIFF
--- a/config/packages.cmake
+++ b/config/packages.cmake
@@ -6,8 +6,8 @@
 # /@@////   /@@/@@@@@@@/@@       ////////@@/@@
 # /@@       /@@/@@//// //@@    @@       /@@/@@
 # /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
-# //       ///  //////   //////  ////////  // 
-# 
+# //       ///  //////   //////  ////////  //
+#
 # Copyright (c) 2016 Los Alamos National Laboratory, LLC
 # All rights reserved
 #~----------------------------------------------------------------------------~#
@@ -27,6 +27,19 @@ else()
 endif()
 
 set(FLECSI_RUNTIME_LIBRARIES)
+
+#------------------------------------------------------------------------------#
+# DBC
+#------------------------------------------------------------------------------#
+if(FLECSI_DBC_ACTION STREQUAL "throw")
+  add_definitions(-DFLECSI_DBC_THROW)
+elseif(FLECSI_DBC_ACTION STREQUAL "notify")
+  add_definitions(-DFLECSI_DBC_NOTIFY)
+endif()
+
+if(FLECSI_DBC_REQUIRE)
+  add_definitions(-DFLECSI_REQUIRE_ON)
+endif()
 
 #------------------------------------------------------------------------------#
 # OpenSSL
@@ -103,7 +116,7 @@ elseif(FLECSI_RUNTIME_MODEL STREQUAL "mpilegion")
   if(NOT ENABLE_MPI)
     message (FATAL_ERROR "MPI is required for the mpilegion runtime model")
   endif()
- 
+
   set(_runtime_path ${PROJECT_SOURCE_DIR}/flecsi/execution/mpilegion)
 
   if(NOT APPLE)
@@ -119,7 +132,7 @@ elseif(FLECSI_RUNTIME_MODEL STREQUAL "mpilegion")
 #
 else(FLECSI_RUNTIME_MODEL STREQUAL "serial")
 
-  message(FATAL_ERROR "Unrecognized runtime selection")  
+  message(FATAL_ERROR "Unrecognized runtime selection")
 
 endif(FLECSI_RUNTIME_MODEL STREQUAL "serial")
 

--- a/config/project.cmake
+++ b/config/project.cmake
@@ -6,8 +6,8 @@
 # /@@////   /@@/@@@@@@@/@@       ////////@@/@@
 # /@@       /@@/@@//// //@@    @@       /@@/@@
 # /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
-# //       ///  //////   //////  ////////  // 
-# 
+# //       ///  //////   //////  ////////  //
+#
 # Copyright (c) 2016 Los Alamos National Laboratory, LLC
 # All rights reserved
 #~----------------------------------------------------------------------------~#
@@ -59,6 +59,23 @@ set(FLECSI_RUNTIME_MODEL "${FLECSI_RUNTIME_MODEL}" CACHE STRING
   "Select the runtime model")
 set_property(CACHE FLECSI_RUNTIME_MODEL
   PROPERTY STRINGS ${FLECSI_RUNTIME_MODELS})
+
+#------------------------------------------------------------------------------#
+# Add options for design by contract
+#------------------------------------------------------------------------------#
+
+set(FLECSI_DBC_ACTIONS throw notify nothing)
+
+if(NOT FLECSI_DBC_ACTION)
+  list(GET FLECSI_DBC_ACTIONS 0 FLECSI_DBC_ACTION)
+endif()
+
+set(FLECSI_DBC_ACTION "${FLECSI_DBC_ACTION}" CACHE STRING
+  "Select the design by contract action")
+set_property(CACHE FLECSI_DBC_ACTION PROPERTY STRINGS ${FLECSI_DBC_ACTIONS})
+
+set(FLECSI_DBC_REQUIRE ON CACHE BOOL
+  "Enable DBC Pre/Post Condition Assertions")
 
 #------------------------------------------------------------------------------#
 # Enable Boost.Preprocessor

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ ARG CI
 ARG TRAVIS
 ARG TRAVIS_BRANCH
 ARG TRAVIS_JOB_NUMBER
-ARG TRAVIS_PULL_REQUEST 
+ARG TRAVIS_PULL_REQUEST
 ARG TRAVIS_JOB_ID
 ARG TRAVIS_TAG
 ARG TRAVIS_REPO_SLUG
@@ -86,7 +86,7 @@ RUN cd .. && if [ ${SONARQUBE} ]; then \
        -Dsonar.github.pullRequest=${TRAVIS_PULL_REQUEST} \
        -Dsonar.github.repository=${TRAVIS_REPO_SLUG} \
        -Dsonar.github.oauth=${SONARQUBE_GITHUB_TOKEN}) \
-    -Dsonar.login=${SONARQUBE_TOKEN}; \
+    -Dsonar.login=${SONARQUBE_TOKEN} || true; \
 fi && cd -
 USER root
 RUN make install

--- a/flecsi/utils/CMakeLists.txt
+++ b/flecsi/utils/CMakeLists.txt
@@ -6,8 +6,8 @@
 # /@@////   /@@/@@@@@@@/@@       ////////@@/@@
 # /@@       /@@/@@//// //@@    @@       /@@/@@
 # /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
-# //       ///  //////   //////  ////////  // 
-# 
+# //       ///  //////   //////  ////////  //
+#
 # Copyright (c) 2016 Los Alamos National Laboratory, LLC
 # All rights reserved
 #~----------------------------------------------------------------------------~#
@@ -15,6 +15,8 @@
 set(utils_HEADERS
   any.h
   array_ref.h
+  dbc.h
+  dbc_impl.h
   bitfield.h
   common.h
   const_string.h
@@ -37,11 +39,31 @@ set(utils_HEADERS
 )
 
 set(utils_SOURCES
+  dbc_impl.cc
   common.cc
   PARENT_SCOPE
 )
 
 set(utils_HEADERS ${utils_HEADERS} PARENT_SCOPE)
+
+cinch_add_unit(any
+  SOURCES test/any.cc
+)
+
+cinch_add_unit(dbc
+  SOURCES test/dbc_test.cc
+  LIBRARIES flecsi
+)
+
+cinch_add_unit(dbc-no-assert
+  SOURCES test/dbc_test_no_assert.cc
+  LIBRARIES flecsi
+)
+
+cinch_add_unit(dbc-notify
+  SOURCES test/dbc_test_notify.cc
+  LIBRARIES flecsi
+)
 
 cinch_add_unit(const_string
   SOURCES test/const_string.cc
@@ -53,10 +75,6 @@ cinch_add_unit(factory
 
 cinch_add_unit(reorder
   SOURCES test/reorder.cc
-)
-
-cinch_add_unit(any
-  SOURCES test/any.cc
 )
 
 cinch_add_unit(reflection

--- a/flecsi/utils/CMakeLists.txt
+++ b/flecsi/utils/CMakeLists.txt
@@ -52,17 +52,17 @@ cinch_add_unit(any
 
 cinch_add_unit(dbc
   SOURCES test/dbc_test.cc
-  LIBRARIES flecsi
+  LIBRARIES flecsi ${CINCH_RUNTIME_LIBRARIES}
 )
 
 cinch_add_unit(dbc-no-assert
   SOURCES test/dbc_test_no_assert.cc
-  LIBRARIES flecsi
+  LIBRARIES flecsi ${CINCH_RUNTIME_LIBRARIES}
 )
 
 cinch_add_unit(dbc-notify
   SOURCES test/dbc_test_notify.cc
-  LIBRARIES flecsi
+  LIBRARIES flecsi ${CINCH_RUNTIME_LIBRARIES}
 )
 
 cinch_add_unit(const_string

--- a/flecsi/utils/dbc.h
+++ b/flecsi/utils/dbc.h
@@ -1,0 +1,207 @@
+// Assert.hh
+// T. M. Kelley
+// Jan. 10, 2010
+// Header for Assert
+// (c) Copyright 2011 LANSLLC all rights reserved.
+
+#ifndef FLECSI_UTILS_DBC_H
+#define FLECSI_UTILS_DBC_H
+
+#define IM_OK_TO_INCLUDE_DBC_IMPL
+#include "dbc_impl.h"
+#undef IM_OK_TO_INCLUDE_DBC_IMPL
+#include <functional> // std::function
+#include <sstream>
+#include <string>
+
+/**\file dbc.h
+ *
+ * \brief Design By Contract (DBC) assertions.
+ *
+ *  Based on the Draco DBC system.
+ *
+ *  This header provides several generic design-by-contract macros:
+ *  * Require: Assert precondition is true.
+ *  * Check: Invariant within function call
+ *  * Ensure: Assert postcondition
+ *  * Insist: Always on macro assertion
+ *
+ *  Additional useful assertions are supplied:
+ *  *    Equal(x,y): (x == y)
+ *  *    InOpenRange(x,min,max): x > min && x < max
+ *  *    GreaterThan(x,min): x > max
+ *  *    GreaterEqual(x,min): x >= max
+ *  *    LessThan(x,max): x < max
+ *
+ *  The behavior of failing any of these assertions can be tuned to
+ *  * throw an exception,
+ *  * write a message to std::err, or
+ *  * return a bool
+ *
+ *  Behavior is contolled by FLECSI_DBC_ACTION and FLECSI_REQUIRE_ON
+ *  in the build system.
+ *
+ *  Set FLECSI_DBC_ACTION={throw, notify, nothing} to set the
+ *  DBC action.
+ *
+ *  Set FLECSI_REQUIRE_ON=1 to enable Require, Check, and Ensure.
+ *
+ *  Note that Insist is always on. Probably not good in inner loops, etc. It's
+ *  for the things that absolutely must always be true.
+ */
+
+namespace flecsi
+{
+namespace dbc{
+
+// Possible DBC actions
+inline void throw_exception(std::string const & cond, const char * file_name,
+  const char * func_name, int line)
+{
+  // printf("%s:%i \n",__FUNCTION__,__LINE__);
+  std::string msg(build_message(cond,file_name,func_name,line));
+  throw std::logic_error(msg);
+} // throw_exception
+
+inline void notify(std::string const & cond, const char * file_name,
+  const char * func_name, int line){
+  // printf("%s:%i \n",__FUNCTION__,__LINE__);
+  std::ostream &s(*p_str);
+  s << build_message(cond,file_name,func_name,line);
+  return;
+} // notify
+
+inline void do_nothing(std::string const &, const char *, const char *, int) {
+  // printf("%s:%i \n",__FUNCTION__,__LINE__);
+}
+
+namespace{
+#ifdef FLECSI_DBC_THROW
+action_t dbc_action(throw_exception);
+#elif defined FLECSI_DBC_NOTIFY
+action_t dbc_action(notify);
+#else
+action_t dbc_action(do_nothing);
+#endif // FLECSI_DBC_THROW
+} // anonymous::
+
+/**\brief assert that a == b. Give names for a and b. */
+template <class eq_t>
+inline
+bool equal_func(eq_t const & a, eq_t const & b, char const * a_name_cstr,
+  char const * b_name_cstr, const char * file_name,
+  const char * func_name, int line)
+{
+  auto gen = [&](){
+    std::string const a_name(a_name_cstr);
+    std::string const b_name(b_name_cstr);
+    std::string const errstr(a_name + " != " + b_name);
+    return errstr;
+  };
+  bool cond = a == b;
+  assertf_l(cond,gen,file_name,func_name,line,dbc_action);
+  return cond;
+} // equal_func
+
+/**\brief min < x < max */
+template <typename comp_t>
+inline
+bool in_open_range_func(comp_t const & x, comp_t const & min,
+  comp_t const & max, char const * const name, const char * file_name,
+  const char * func_name, int line)
+{
+  std::stringstream errstr;
+  bool cond = x > min && x < max;
+  errstr << name << " (" << x << ") was not in range ("
+         << min << "," << max << ")";
+  assertf(cond,errstr.str(),file_name,func_name,line,dbc_action);
+  return cond;
+} // InOpenRange
+
+template <typename gt_t>
+inline
+bool greater_than_func(gt_t const & x, gt_t const & min,
+                      char const * name, const char * file_name,
+                      const char * func_name, int line)
+{
+  bool cond = x > min;
+  auto gen = [&](){
+    std::stringstream errstr;
+    errstr << name << " (" << x << ") <= " << min;
+    return errstr.str();
+  };
+  assertf_l(cond,gen,file_name,func_name,line,dbc_action);
+  return cond;
+} // GreaterThan
+
+template <typename gt_t>
+inline
+bool greater_equal_func(gt_t const & x, gt_t const & min,
+                      char const * name, const char * file_name,
+                      const char * func_name, int line)
+{
+  bool cond = x >= min;
+  auto gen = [&](){
+    std::stringstream errstr;
+    errstr << name << " (" << x << ") < " << min;
+    return errstr.str();
+  };
+  assertf_l(cond,gen,file_name,func_name,line,dbc_action);
+  return cond;
+} // GreaterEqual
+
+template <typename gt_t>
+inline
+bool less_than_func(gt_t const & x, gt_t const & min,
+                      char const * name, const char * file_name,
+                      const char * func_name, int line)
+{
+  bool cond = x < min;
+  auto gen = [&](){
+    std::stringstream errstr;
+    errstr << name << " (" << x << ") >= " << min;
+    return errstr.str();
+  };
+  assertf_l(cond,gen,file_name,func_name,line,dbc_action);
+  return cond;
+} // GreaterThan
+
+#define Insist(c, cs) assertf(c,cs,__FILE__,__FUNCTION__,__LINE__,dbc_action);
+
+#ifdef FLECSI_REQUIRE_ON
+/*! \def Require(condition,descriptive_string): Precondition assertion. */
+#define Require(c,cs) assertf(c,cs,__FILE__,__FUNCTION__,__LINE__,dbc_action);
+/*! \def Check(condition,descriptive_string): Invariant assertion. */
+#define Check(c,cs) assertf(c,cs,__FILE__,__FUNCTION__,__LINE__,dbc_action);
+/*! \def Ensure(condition,descriptive_string): Postcondition assertion. */
+#define Ensure(c,cs) assertf(c,cs,__FILE__,__FUNCTION__,__LINE__,dbc_action);
+/*! \def Equal(x,y): Assert x == y */
+#define Equal(a,b) equal_func(a,b,#a,#b,__FILE__,__FUNCTION__,__LINE__);
+/*! \def InOpenRange(x,min,max): Assert x > min && x < max */
+#define InOpenRange(x,mn,mx) in_open_range_func(x,mn,mx,#x,__FILE__,__FUNCTION__,__LINE__);
+/*! \def GreaterThan(x,min): Assert x > min */
+#define GreaterThan(x,mn) greater_than_func(x,mn,#x,__FILE__,__FUNCTION__,__LINE__);
+/*! \def GreaterEqual(x,min): Assert x >= min */
+#define GreaterEqual(x,mn) greater_equal_func(x,mn,#x,__FILE__,__FUNCTION__,__LINE__);
+/*! \def LessThan(x,max): Assert x < max */
+#define LessThan(x,mx) less_than_func(x,mx,#x,__FILE__,__FUNCTION__,__LINE__);
+
+#else // REQUIRE_ON
+
+#define Require(c,cs)
+#define Check(c,cs)
+#define Ensure(c,cs)
+#define Equal(a,b) ((a) == (b))
+#define InOpenRange(x,mn,mx) ((x) > (mn) && (x) < (mx))
+#define GreaterThan(x,mn) ((x) > (mn))
+#define GreaterEqual(x,mn) ((x) >= (mn))
+#define LessThan(x,mn) ((x) < (mn))
+
+#endif // REQUIRE_ON
+
+} // dbc::
+} // flecsi::
+
+#endif
+
+// End of file

--- a/flecsi/utils/dbc.h
+++ b/flecsi/utils/dbc.h
@@ -110,11 +110,14 @@ bool in_open_range_func(comp_t const & x, comp_t const & min,
   comp_t const & max, char const * const name, const char * file_name,
   const char * func_name, int line)
 {
-  std::stringstream errstr;
+  auto gen = [&](){
+    std::stringstream errstr;
+    errstr << name << " (" << x << ") was not in range ("
+           << min << "," << max << ")";
+    return errstr.str();
+  };
   bool cond = x > min && x < max;
-  errstr << name << " (" << x << ") was not in range ("
-         << min << "," << max << ")";
-  assertf(cond,errstr.str(),file_name,func_name,line,dbc_action);
+  assertf_l(cond,gen,file_name,func_name,line,dbc_action);
   return cond;
 } // InOpenRange
 

--- a/flecsi/utils/dbc_impl.cc
+++ b/flecsi/utils/dbc_impl.cc
@@ -1,0 +1,39 @@
+// assert.cc
+// T. M. Kelley
+// May 02, 2017
+// (c) Copyright 2017 LANSLLC, all rights reserved
+
+#define IM_OK_TO_INCLUDE_DBC_IMPL
+#include "dbc_impl.h"
+#undef IM_OK_TO_INCLUDE_DBC_IMPL
+#include <iostream>
+#include <sstream>
+
+namespace flecsi{
+
+namespace dbc{
+
+std::ostream *p_str = &std::cerr;
+
+std::string build_message(std::string const & cond,const char * file_name,
+  const char * func_name, int line){
+  std::stringstream s;
+  s << file_name << ":" << line << ":" << func_name << " assertion '"
+    << cond << "' failed." << std::endl;
+  return s.str();
+} // build_message
+
+bool assertf(bool cond, std::string const & cond_str, const char * file_name,
+  const char * func_name, int line, action_t &action){
+  if(!cond){
+    action(cond_str,file_name,func_name,line);
+  }
+  return cond;
+} // assertf
+
+} // dbc::
+
+} // flecsi::
+
+
+// End of file

--- a/flecsi/utils/dbc_impl.h
+++ b/flecsi/utils/dbc_impl.h
@@ -1,0 +1,55 @@
+// Assert.hh
+// T. M. Kelley
+// Jan. 10, 2010
+// Header for Assert
+// (c) Copyright 2011 LANSLLC all rights reserved.
+
+#ifndef FLECSI_UTILS_DBC_IMPL_H
+#define FLECSI_UTILS_DBC_IMPL_H
+
+#ifndef IM_OK_TO_INCLUDE_DBC_IMPL
+#warning "You almost certainly do not want to include this dbc_impl.h--use dbc.h!"
+#endif
+
+#include <functional> // std::function
+#include <string>
+
+/* Implementations for the DBC system. Do not include this directly. */
+
+namespace flecsi
+{
+namespace dbc{
+
+using action_t =
+  std::function<void(std::string const &, const char *, const char *, int)>;
+
+/**\brief Constructs error/exception message */
+std::string build_message(std::string const & cond, const char * file_name,
+  const char * func_name, int line);
+
+/**\brief Stream used for error reporting, defaults to std::cerr. */
+extern std::ostream *p_str;
+
+/**\brief Core assertion function. */
+bool assertf(bool cond, std::string const & cond_str, const char * file_name,
+  const char * func_name, int line, action_t &);
+
+/**\brief Core assertion function, with some hope of not constructing the
+ * error string every single time?
+ */
+template <class error_msg_generator>
+bool assertf_l(bool cond, error_msg_generator & gen, const char * file_name,
+  const char * func_name, int line, action_t &action){
+  if(!cond){
+    std::string errstr = gen();
+    action(errstr,file_name,func_name,line);
+  }
+  return cond;
+
+}
+
+} // dbc::
+} // flecsi::
+#endif // include guard
+
+// End of file

--- a/flecsi/utils/test/dbc_test.cc
+++ b/flecsi/utils/test/dbc_test.cc
@@ -1,0 +1,171 @@
+// assert.cc
+// T. M. Kelley
+// May 02, 2017
+// (c) Copyright 2017 LANSLLC, all rights reserved
+
+
+/* This file tests FleCSI DBC assertions with action set to THROW and
+ * DBC turned on.
+ */
+
+#include "cinchtest.h"
+/* Test will take control of the test environment */
+#ifndef FLECSI_REQUIRE_ON
+#define FLECSI_REQUIRE_ON
+#endif
+#ifndef FLECSI_DBC_THROW
+#define FLECSI_DBC_THROW
+#endif
+
+#ifdef FLECSI_DBC_NOTIFY
+#undef FLECSI_DBC_NOTIFY
+#endif
+
+#include "flecsi/utils/dbc.h"
+
+
+using namespace flecsi::dbc;
+
+TEST(dbc,compiles){
+  ASSERT_TRUE(true);
+}
+
+/**\brief Is s1 a substring of s2? */
+inline
+bool is_substring_of(std::string const &s1, std::string const &s2){
+  return s2.find(s1) != std::string::npos;
+}
+
+/**\brief Check that s1 is a substring of s2, print them if not*/
+inline
+bool check_messages(std::string const &s1, std::string const &s2){
+  bool const msg_ok(is_substring_of(s1,s2));
+  if(!msg_ok){
+    printf(
+      "%s:%i expected: %s\n", __FUNCTION__, __LINE__, s1.c_str());
+    printf("%s:%i actual: %s\n",__FUNCTION__,__LINE__,s2.c_str());
+  }
+  return msg_ok;
+} // check_messages
+
+TEST(dbc,Equal){
+  // int
+  {
+    int i = 1;
+    int j = 2;
+    int k = 1;
+    int fail_line = -1;
+    try{
+      bool ret_val(true);
+      ret_val = Equal(i,k);
+      EXPECT_TRUE(ret_val); // clang-format off
+      fail_line = __LINE__;ret_val = Equal(i,j);
+      // clang-format on
+      /* Should not get here with exceptions*/
+#if (defined FLECSI_REQUIRE_ON && defined FLECSI_DBC_THROW)
+      EXPECT_TRUE(false);
+#elif defined FLECSI_REQUIRE_ON
+      EXPECT_EQ(false,ret_val);
+#else
+      EXPECT_EQ(true,ret_val);
+#endif
+    }
+    catch(std::exception & e){
+      // exact message depends on build details. This part shd be invariant:
+      std::stringstream exp_msg;
+      exp_msg << "flecsi/utils/test/dbc_test.cc:" << fail_line
+        << ":TestBody assertion 'i != j' failed";
+      std::string excmsg(e.what());
+      EXPECT_TRUE(check_messages(exp_msg.str(),excmsg));
+    }
+  }// int
+} // TEST(dbc,Equal){
+
+TEST(dbc,InOpenRange){
+  // int
+  {
+    int i = 1;
+    int j = 2;
+    int k = 4;
+    int fail_line = -1;
+    try{
+      bool ret_val(true);
+      ret_val = InOpenRange(j,i,k);
+      EXPECT_TRUE(ret_val); // clang-format off
+      fail_line = __LINE__;ret_val = InOpenRange(i,j,k);
+      // clang-format on
+      /* Should not get here with exceptions*/
+#if (defined FLECSI_REQUIRE_ON && defined FLECSI_DBC_THROW)
+      EXPECT_TRUE(false);
+#elif defined FLECSI_REQUIRE_ON
+      EXPECT_EQ(false,ret_val);
+#else
+      EXPECT_EQ(true,ret_val);
+#endif
+    }
+    catch(std::exception & e){
+      // exact message depends on build details. This part shd be invariant:
+      std::stringstream exp_msg;
+      exp_msg << "flecsi/utils/test/dbc_test.cc:" << fail_line
+        << ":TestBody assertion 'i (1) was not in range (2,4)' failed";
+      std::string excmsg(e.what());
+      EXPECT_TRUE(check_messages(exp_msg.str(),excmsg));
+    }
+  }// int
+} // TEST(dbc,InOpenRange){
+
+TEST(dbc,Insist){
+  // int
+  {
+    int i = 1;
+    int j = 2;
+    int k = 4;
+    int fail_line = -1;
+    try{
+      fail_line = __LINE__; Insist(i == j, "i == j")
+#if (defined FLECSI_REQUIRE_ON && defined FLECSI_DBC_THROW)
+      EXPECT_TRUE(false);  // Should not get here with exceptions
+#else
+      EXPECT_TRUE(true);
+#endif
+    }
+    catch(std::exception & e){
+      // exact message depends on build details. This part shd be invariant:
+      std::stringstream exp_msg;
+      exp_msg << "flecsi/utils/test/dbc_test.cc:" << fail_line
+        << ":TestBody assertion 'i == j' failed";
+      std::string excmsg(e.what());
+      EXPECT_TRUE(check_messages(exp_msg.str(),excmsg));
+    }
+  }// int
+} // TEST(dbc,Insist
+
+TEST(dbc,LessThan){
+  // int
+  {
+    int i = 1;
+    int j = 2;
+    int k = 4;
+    int fail_line = -1;
+    try{
+      bool ret_val = LessThan(i,j);
+      EXPECT_TRUE(ret_val);
+      fail_line = __LINE__; ret_val = LessThan(j,i);
+#if (defined FLECSI_REQUIRE_ON && defined FLECSI_DBC_THROW)
+      EXPECT_TRUE(false);  // Should not get here with exceptions
+#else
+      EXPECT_TRUE(true);
+#endif
+    }
+    catch(std::exception & e){
+      // exact message depends on build details. This part shd be invariant:
+      std::stringstream exp_msg;
+      exp_msg << "flecsi/utils/test/dbc_test.cc:" << fail_line
+        << ":TestBody assertion 'j (2) >= 1' failed";
+      std::string excmsg(e.what());
+      EXPECT_TRUE(check_messages(exp_msg.str(),excmsg));
+    }
+  }// int
+} // TEST(dbc,InOpenRange){
+
+// End of file

--- a/flecsi/utils/test/dbc_test_no_assert.cc
+++ b/flecsi/utils/test/dbc_test_no_assert.cc
@@ -63,7 +63,7 @@ TEST(dbc_no_assert,Equal){
 #elif REQUIRE_ON
       EXPECT_EQ(false,ret_val);
 #else
-      EXPECT_EQ(false,ret_val);
+      EXPECT_FALSE(ret_val);
 #endif
     }
     catch(std::exception & e){
@@ -96,7 +96,7 @@ TEST(dbc_no_assert,InOpenRange){
 #elif REQUIRE_ON
       EXPECT_EQ(false,ret_val);
 #else
-      EXPECT_EQ(false,ret_val);
+      EXPECT_FALSE(ret_val);
 #endif
     }
     catch(std::exception & e){

--- a/flecsi/utils/test/dbc_test_no_assert.cc
+++ b/flecsi/utils/test/dbc_test_no_assert.cc
@@ -1,0 +1,168 @@
+// dbc_test_no_assert.cc
+// T. M. Kelley
+// May 02, 2017
+// (c) Copyright 2017 LANSLLC, all rights reserved
+
+
+#include "cinchtest.h"
+/* Test will take control of the test environment */
+#ifdef FLECSI_DBC_THROW
+#undef FLECSI_DBC_THROW
+#endif
+
+#ifdef FLECSI_REQUIRE_ON
+#undef FLECSI_REQUIRE_ON
+#endif
+
+#ifdef FLECSI_DBC_NOTIFY
+#undef FLECSI_DBC_NOTIFY
+#endif
+
+#include "flecsi/utils/dbc.h"
+
+using namespace flecsi::dbc;
+
+TEST(dbc_no_assert,compiles){
+  ASSERT_TRUE(true);
+}
+
+/**\brief Is s1 a substring of s2? */
+inline
+bool is_substring_of(std::string const &s1, std::string const &s2){
+  return s2.find(s1) != std::string::npos;
+}
+
+/**\brief Check that s1 is a substring of s2, print them if not*/
+inline
+bool check_messages(std::string const &s1, std::string const &s2){
+  bool const msg_ok(is_substring_of(s1,s2));
+  if(!msg_ok){
+    printf(
+      "%s:%i expected: %s\n", __FUNCTION__, __LINE__, s1.c_str());
+    printf("%s:%i actual: %s\n",__FUNCTION__,__LINE__,s2.c_str());
+  }
+  return msg_ok;
+} // check_messages
+
+TEST(dbc_no_assert,Equal){
+  // int
+  {
+    int i = 1;
+    int j = 2;
+    int k = 1;
+    int fail_line = -1;
+    try{
+      bool ret_val(true);
+      ret_val = Equal(i,k);
+      EXPECT_TRUE(ret_val); // clang-format off
+      fail_line = __LINE__;ret_val = Equal(i,j);
+      // clang-format on
+      /* Should not get here with exceptions*/
+#if (REQUIRE_ON && FLECSI_DBC_THROW)
+      EXPECT_TRUE(false);
+#elif REQUIRE_ON
+      EXPECT_EQ(false,ret_val);
+#else
+      EXPECT_EQ(false,ret_val);
+#endif
+    }
+    catch(std::exception & e){
+      // exact message depends on build details. This part shd be invariant:
+      std::stringstream exp_msg;
+      exp_msg << "flecsi/utils/test/dbc_test_no_assert.cc:" << fail_line
+        << ":TestBody Assertion 'i != j' failed";
+      std::string excmsg(e.what());
+      EXPECT_TRUE(check_messages(exp_msg.str(),excmsg));
+    }
+  }// int
+} // TEST(dbc,Equal){
+
+TEST(dbc_no_assert,InOpenRange){
+  // int
+  {
+    int i = 1;
+    int j = 2;
+    int k = 4;
+    int fail_line = -1;
+    try{
+      bool ret_val(true);
+      ret_val = InOpenRange(j,i,k);
+      EXPECT_TRUE(ret_val); // clang-format off
+      fail_line = __LINE__;ret_val = InOpenRange(i,j,k);
+      // clang-format on
+      /* Should not get here with exceptions*/
+#if (REQUIRE_ON && FLECSI_DBC_THROW)
+      EXPECT_TRUE(false);
+#elif REQUIRE_ON
+      EXPECT_EQ(false,ret_val);
+#else
+      EXPECT_EQ(false,ret_val);
+#endif
+    }
+    catch(std::exception & e){
+      // exact message depends on build details. This part shd be invariant:
+      std::stringstream exp_msg;
+      exp_msg << "flecsi/utils/test/dbc_test_no_assert.cc:" << fail_line
+        << ":TestBody Assertion 'i (1) was not in range (2,4)' failed";
+      std::string excmsg(e.what());
+      EXPECT_TRUE(check_messages(exp_msg.str(),excmsg));
+    }
+  }// int
+} // TEST(dbc,InOpenRange){
+
+TEST(dbc_no_assert,Insist){
+  // int
+  {
+    int i = 1;
+    int j = 2;
+    int k = 4;
+    int fail_line = -1;
+    try{
+      fail_line = __LINE__; Insist(i == j, "i == j")
+#if (REQUIRE_ON && FLECSI_DBC_THROW)
+      EXPECT_TRUE(false);  // Should not get here with exceptions
+#else
+      EXPECT_TRUE(true);
+#endif
+    }
+    catch(std::exception & e){
+      // exact message depends on build details. This part shd be invariant:
+      std::stringstream exp_msg;
+      exp_msg << "flecsi/utils/test/dbc_test_no_assert.cc:" << fail_line
+        << ":TestBody Assertion 'i == j' failed";
+      std::string excmsg(e.what());
+      EXPECT_TRUE(check_messages(exp_msg.str(),excmsg));
+    }
+  }// int
+} // TEST(dbc,InOpenRange){
+
+TEST(dbc_no_assert,LessThan){
+  // int
+  {
+    int i = 1;
+    int j = 2;
+    int k = 4;
+    int fail_line = -1;
+    try{
+      bool ret_val = LessThan(i,j);
+      EXPECT_TRUE(ret_val);
+      fail_line = __LINE__; ret_val = LessThan(j,i);
+#if (REQUIRE_ON && FLECSI_DBC_THROW)
+      EXPECT_TRUE(false);  // Should not get here with exceptions
+#else
+      EXPECT_FALSE(ret_val);
+#endif
+    }
+    catch(std::exception & e){
+      // exact message depends on build details. This part shd be invariant:
+      std::stringstream exp_msg;
+      exp_msg << "flecsi/utils/test/dbc_test_no_assert.cc:" << fail_line
+        << ":TestBody Assertion 'j (2) >= 1' failed";
+      std::string excmsg(e.what());
+      EXPECT_TRUE(check_messages(exp_msg.str(),excmsg));
+    }
+  }// int
+} // TEST(dbc,InOpenRange){
+
+
+// End of file

--- a/flecsi/utils/test/dbc_test_notify.cc
+++ b/flecsi/utils/test/dbc_test_notify.cc
@@ -1,0 +1,164 @@
+// dbc_test_no_assert.cc
+// T. M. Kelley
+// May 02, 2017
+// (c) Copyright 2017 LANSLLC, all rights reserved
+
+
+/* Test will take control of the test environment */
+#include "cinchtest.h"
+
+// #if defined FLECSI_REQUIRE_ON && defined FLECSI_DBC_NOTIFY
+
+#ifdef FLECSI_DBC_THROW
+#undef FLECSI_DBC_THROW
+#endif
+
+#ifndef FLECSI_DBC_NOTIFY
+#define FLECSI_DBC_NOTIFY
+#endif
+
+#ifndef FLECSI_REQUIRE_ON
+#define FLECSI_REQUIRE_ON
+#endif
+
+#include "flecsi/utils/dbc.h"
+
+using namespace flecsi::dbc;
+
+TEST(dbc_notify,compiles){
+  ASSERT_TRUE(true);
+}
+
+/**\brief Is s1 a substring of s2? */
+inline
+bool is_substring_of(std::string const &s1, std::string const &s2){
+  return s2.find(s1) != std::string::npos;
+}
+
+std::ostream *p_temp = nullptr;
+
+namespace{
+// switch DBC output stream to p_o
+void divert_stream(std::ostream *p_o){
+  p_temp = p_str;
+  p_str = p_o;
+};
+// switch DBC output back to original value
+std::ostream * restore_stream(){
+  std::ostream *p2 = p_str;
+  p_str = p_temp;
+  return p2;
+}
+} // anonymous::
+
+/**\brief Check that s1 is a substring of s2, print them if not*/
+inline
+bool check_messages(std::string const &s1, std::string const &s2){
+  bool const msg_ok(is_substring_of(s1,s2));
+  if(!msg_ok){
+    printf(
+      "%s:%i expected: %s\n", __FUNCTION__, __LINE__, s1.c_str());
+    printf("%s:%i actual: %s\n",__FUNCTION__,__LINE__,s2.c_str());
+  }
+  return msg_ok;
+} // check_messages
+
+TEST(dbc_notify,Equal){
+  int i = 1;
+  int j = 2;
+  int k = 1;
+  int fail_line = -1;
+  std::stringstream outs;
+  divert_stream(&outs);
+  try{
+    bool ret_val(true);
+    ret_val = Equal(i,k);
+    EXPECT_TRUE(ret_val); // clang-format off
+    fail_line = __LINE__;ret_val = Equal(i,j);
+    // clang-format on
+    EXPECT_FALSE(ret_val);
+    std::string fail_msg(outs.str());
+    std::stringstream exp_msg;
+    exp_msg << "flecsi/utils/test/dbc_test_notify.cc:" << fail_line
+      << ":TestBody assertion 'i != j' failed";
+    EXPECT_TRUE(check_messages(exp_msg.str(),fail_msg));
+  }
+  catch(std::exception & e){
+    EXPECT_TRUE(false); // shouldn't get here!
+  }
+  restore_stream();
+} // TEST(dbc,Equal){
+
+TEST(dbc_notify,InOpenRange){
+  int i = 1;
+  int j = 2;
+  int k = 4;
+  int fail_line = -1;
+  std::stringstream outs;
+  divert_stream(&outs);
+  try{
+    bool ret_val(true);
+    ret_val = InOpenRange(j,i,k);
+    EXPECT_TRUE(ret_val); // clang-format off
+    fail_line = __LINE__;ret_val = InOpenRange(i,j,k);
+    // clang-format on
+    std::stringstream exp_msg;
+    exp_msg << "flecsi/utils/test/dbc_test_notify.cc:" << fail_line
+      << ":TestBody assertion 'i (1) was not in range (2,4)' failed";
+    std::string excmsg(outs.str());
+    EXPECT_TRUE(check_messages(exp_msg.str(),excmsg));
+    /* Should not get here with exceptions*/
+  }
+  catch(std::exception & e){
+    EXPECT_TRUE(false);
+  }
+  restore_stream();
+} // TEST(dbc,InOpenRange){
+
+TEST(dbc_notify,Insist){
+  int i = 1;
+  int j = 2;
+  int k = 4;
+  int fail_line = -1;
+  std::stringstream outs;
+  divert_stream(&outs);
+  try{
+    fail_line = __LINE__; Insist(i == j, "i == j")
+    std::stringstream exp_msg;
+    exp_msg << "flecsi/utils/test/dbc_test_notify.cc:" << fail_line
+      << ":TestBody assertion 'i == j' failed";
+    std::string excmsg(outs.str());
+    EXPECT_TRUE(check_messages(exp_msg.str(),excmsg));
+  }
+  catch(std::exception & e){
+    EXPECT_TRUE(false);
+  }
+  restore_stream();
+} // TEST(dbc,InOpenRange){
+
+TEST(dbc_notify, LessThan)
+{
+  int i = 1;
+  int j = 2;
+  int k = 4;
+  int fail_line = -1;
+  std::stringstream outs;
+  divert_stream(&outs);
+  try {
+    bool ret_val = LessThan(i, j);
+    EXPECT_TRUE(ret_val);
+    // clang-format off
+    fail_line = __LINE__;ret_val = LessThan(j, i);
+    // clang-format on
+    std::stringstream exp_msg;
+    exp_msg << "flecsi/utils/test/dbc_test_notify.cc:" << fail_line
+            << ":TestBody assertion 'j (2) >= 1' failed";
+    std::string excmsg(outs.str());
+    EXPECT_TRUE(check_messages(exp_msg.str(), excmsg));
+  } catch (std::exception & e) {
+    EXPECT_TRUE(false);
+  }
+  restore_stream();
+} // TEST(dbc,InOpenRange){
+
+// End of file

--- a/flecsi/utils/utils.md
+++ b/flecsi/utils/utils.md
@@ -11,6 +11,8 @@ going to be in the Doxygen documentation.
 
 --------------------------------------------------------------------------------
 
+## Design-By-Contract Assertions (DBC)
+
 ## Template Metaprogramming
 
 ### Tuple Manipulation


### PR DESCRIPTION
DBC. Inspired by the old Draco DBC system. This version provides pre- and post-conditions assertions, invariant assertions, and several common cases (Equal, GreaterThan, LessThan, etc). It also provides tunable assertion actions: throw exception, notify to (tunable) std::ostream, or no action.

I think it's right in terms of keeping conditions out of inline code (doesn't kill coverage with lots of untested branches) and delaying error message construction until an assertion has failed.