### PR TITLE
Initial HPX implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - DISTRO=ubuntu_mpich RUNTIME=mpi WERROR=yes
     - DISTRO=ubuntu COVERAGE=ON RUNTIME=legion SONARQUBE=ON
     - DISTRO=ubuntu COVERAGE=ON RUNTIME=mpi    SONARQUBE=ON
+    - DISTRO=ubuntu COVERAGE=ON RUNTIME=hpx    SONARQUBE=ON
 
     - DISTRO=fedora RUNTIME=legion    DOCKERHUB=true
     - DISTRO=fedora RUNTIME=legion    IGNORE_NOCI=true
@@ -33,6 +34,7 @@ env:
     - DISTRO=fedora_mpich RUNTIME=mpi WERROR=yes
     - DISTRO=fedora RUNTIME=legion COVERAGE=ON
     - DISTRO=fedora RUNTIME=mpi    COVERAGE=ON
+    - DISTRO=fedora RUNTIME=hpx    COVERAGE=ON
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ env:
     - DISTRO=fedora RUNTIME=mpi    DOCKERHUB=true
     - DISTRO=fedora RUNTIME=mpi    IGNORE_NOCI=true
     - DISTRO=fedora RUNTIME=mpi    WERROR=yes
+    - DISTRO=fedora RUNTIME=hpx    DOCKERHUB=true
+    - DISTRO=fedora RUNTIME=hpx    IGNORE_NOCI=true
+    - DISTRO=fedora RUNTIME=hpx    WERROR=yes
     - DISTRO=fedora_mpich RUNTIME=legion DOCKERHUB=true
     - DISTRO=fedora_mpich RUNTIME=legion IGNORE_NOCI=true
     - DISTRO=fedora_mpich RUNTIME=legion WERROR=yes

--- a/config/flecsi-config.h.in
+++ b/config/flecsi-config.h.in
@@ -12,6 +12,7 @@
 
 #define FLECSI_RUNTIME_MODEL_legion 1
 #define FLECSI_RUNTIME_MODEL_mpi 2
+#define FLECSI_RUNTIME_MODEL_hpx 3
 #cmakedefine FLECSI_RUNTIME_MODEL FLECSI_RUNTIME_MODEL_@FLECSI_RUNTIME_MODEL@
 
 //----------------------------------------------------------------------------//

--- a/config/project.cmake
+++ b/config/project.cmake
@@ -85,6 +85,9 @@ if(FLECSI_RUNTIME_MODEL STREQUAL "mpi")
 elseif(FLECSI_RUNTIME_MODEL STREQUAL "legion")
   set(ENABLE_MPI ON CACHE BOOL "Enable MPI" FORCE)
   set(ENABLE_LEGION ON CACHE BOOL "Enable Legion" FORCE)
+elseif(FLECSI_RUNTIME_MODEL STREQUAL "hpx")
+  set(ENABLE_MPI ON CACHE BOOL "Enable MPI" FORCE)
+  set(ENABLE_HPX ON CACHE BOOL "Enable HPX" FORCE)
 endif()
 
 mark_as_advanced(ENABLE_MPI ENABLE_LEGION)
@@ -110,7 +113,7 @@ set(FLECSI_DBC_REQUIRE ON CACHE BOOL
 # Load the cinch extras
 #------------------------------------------------------------------------------#
 
-cinch_load_extras(MPI LEGION)
+cinch_load_extras(MPI LEGION HPX)
 
 #------------------------------------------------------------------------------#
 # Add option for setting id bits
@@ -145,7 +148,7 @@ set(FLECSI_SHARE_DIR ${CMAKE_INSTALL_PREFIX}/share/FleCSI)
 # Add options for runtime selection
 #------------------------------------------------------------------------------#
 
-set(FLECSI_RUNTIME_MODELS legion mpi)
+set(FLECSI_RUNTIME_MODELS legion mpi hpx)
 
 if(NOT FLECSI_RUNTIME_MODEL)
   list(GET FLECSI_RUNTIME_MODELS 0 FLECSI_RUNTIME_MODEL)
@@ -230,11 +233,11 @@ if(FLECSI_RUNTIME_MODEL STREQUAL "legion")
   if(NOT MPI_${MPI_LANGUAGE}_FOUND)
     message (FATAL_ERROR "MPI is required for the legion runtime model")
   endif()
- 
+
   if(NOT Legion_FOUND)
     message (FATAL_ERROR "Legion is required for the legion runtime model")
   endif()
- 
+
   set(_runtime_path ${PROJECT_SOURCE_DIR}/flecsi/execution/legion)
 
   set(FLECSI_RUNTIME_LIBRARIES ${DL_LIBS} ${Legion_LIBRARIES}
@@ -271,12 +274,20 @@ elseif(FLECSI_RUNTIME_MODEL STREQUAL "mpi")
 
   set(FLECSI_RUNTIME_LIBRARIES ${DL_LIBS} ${MPI_LIBRARIES})
 
+elseif(FLECSI_RUNTIME_MODEL STREQUAL "hpx")
+
+  if(NOT HPX_FOUND)
+    message (FATAL_ERROR "HPX is required for the HPX runtime model")
+  endif()
+
+  set(_runtime_path ${PROJECT_SOURCE_DIR}/flecsi/execution/hpx)
+
 #
 # Default
 #
 else()
 
-  message(FATAL_ERROR "Unrecognized runtime selection")  
+  message(FATAL_ERROR "Unrecognized runtime selection")
 
 endif()
 
@@ -407,6 +418,11 @@ if(FLECSI_RUNTIME_LIBRARIES OR COLORING_LIBRARIES)
   )
 endif()
 
+if(FLECSI_RUNTIME_MODEL STREQUAL "hpx")
+
+  hpx_setup_target(FleCSI NONAMEPREFIX)
+
+endif()
 #------------------------------------------------------------------------------#
 # Set application directory
 #------------------------------------------------------------------------------#

--- a/examples/00_simple_drivers/CMakeLists.txt
+++ b/examples/00_simple_drivers/CMakeLists.txt
@@ -8,6 +8,7 @@
 #------------------------------------------------------------------------------#
 #  add_definitions(-DFLECSI_OVERRIDE_DEFAULT_SPECIALIZATION_DRIVER)
   add_definitions(-DFLECSI_ENABLE_SPECIALIZATION_DRIVER)
+  add_definitions(-DFLECSI_ENABLE_SPECIALIZATION_TLT_INIT)
 
 #------------------------------------------------------------------------------#
 # Add source files for example application.
@@ -22,6 +23,8 @@ elseif(FLECSI_RUNTIME_MODEL STREQUAL "legion")
     list(APPEND simple_drivers_src ${exec_path}/legion/runtime_driver.cc )
 elseif(FLECSI_RUNTIME_MODEL STREQUAL "mpi")
     list(APPEND simple_drivers_src ${exec_path}/mpi/runtime_driver.cc )
+elseif(FLECSI_RUNTIME_MODEL STREQUAL "hpx")
+    list(APPEND simple_drivers_src ${exec_path}/hpx/runtime_driver.cc )
 else()
   message(FATAL_ERROR "Unrecognized runtime selection: ${FLECSI_RUNTIME_MODEL}")
 endif()
@@ -37,6 +40,10 @@ add_executable(simple_drivers ${simple_drivers_src})
 #------------------------------------------------------------------------------#
 
 target_link_libraries(simple_drivers FleCSI ${FLECSI_RUNTIME_LIBRARIES})
+
+if(FLECSI_RUNTIME_MODEL STREQUAL "hpx")
+  hpx_setup_target(simple_drivers)
+endif()
 
 #~---------------------------------------------------------------------------~-#
 # Formatting options for vim.

--- a/examples/00_simple_drivers/simple_drivers.cc
+++ b/examples/00_simple_drivers/simple_drivers.cc
@@ -26,8 +26,8 @@ void
 specialization_tlt_init(
   int argc,
   char ** argv
-) 
-{ 
+)
+{
   std::cout<<"inside Specialization Driver"<<std::endl;
 }//specialization_driver
 

--- a/examples/02_tasks_and_drivers/CMakeLists.txt
+++ b/examples/02_tasks_and_drivers/CMakeLists.txt
@@ -6,8 +6,8 @@
 # /@@////   /@@/@@@@@@@/@@       ////////@@/@@
 # /@@       /@@/@@//// //@@    @@       /@@/@@
 # /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
-# //       ///  //////   //////  ////////  // 
-# 
+# //       ///  //////   //////  ////////  //
+#
 # Copyright (c) 2016 Los Alamos National Laboratory, LLC
 # All rights reserved
 #~----------------------------------------------------------------------------~#
@@ -16,7 +16,8 @@
 # Compile definition to include driver
 #------------------------------------------------------------------------------#
 
-if(FLECSI_RUNTIME_MODEL STREQUAL "legion")
+if(FLECSI_RUNTIME_MODEL STREQUAL "legion" OR
+   FLECSI_RUNTIME_MODEL STREQUAL "hpx")
 
   add_definitions(-DFLECSI_ENABLE_SPECIALIZATION_TLT_INIT)
   add_definitions(-DCINCH_OVERRIDE_DEFAULT_INITIALIZATION_DRIVER)
@@ -26,8 +27,13 @@ if(FLECSI_RUNTIME_MODEL STREQUAL "legion")
   #----------------------------------------------------------------------------#
 
   set(exec_path ${PROJECT_SOURCE_DIR}/flecsi/execution)
+if(FLECSI_RUNTIME_MODEL STREQUAL "legion")
   set (exmaple_src      tasks_and_drivers.cc
                         ${exec_path}/legion/runtime_driver.cc)
+elseif(FLECSI_RUNTIME_MODEL STREQUAL "hpx")
+  set (exmaple_src      tasks_and_drivers.cc
+                        ${exec_path}/hpx/runtime_driver.cc)
+endif()
 
   #----------------------------------------------------------------------------#
   # Add a rule to build the executable

--- a/examples/02_tasks_and_drivers/tasks_and_drivers.cc
+++ b/examples/02_tasks_and_drivers/tasks_and_drivers.cc
@@ -5,14 +5,18 @@
 
 #include <flecsi-config.h>
 
-#if FLECSI_RUNTIME_MODEL == FLECSI_RUNTIME_MODEL_legion 
-  #include <mpi.h>
-  #include <legion.h>
+#include <mpi.h>
+#if FLECSI_RUNTIME_MODEL == FLECSI_RUNTIME_MODEL_legion
+#include <legion.h>
 #endif
 
-#include "flecsi/execution/context.h"
-#include "flecsi/execution/common/processor.h"
-#include "flecsi/execution/legion/internal_task.h"
+#include <flecsi/execution/common/processor.h>
+#include <flecsi/execution/context.h>
+#if FLECSI_RUNTIME_MODEL == FLECSI_RUNTIME_MODEL_legion
+#include <flecsi/execution/legion/internal_task.h>
+#elif FLECSI_RUNTIME_MODEL == FLECSI_RUNTIME_MODEL_hpx
+#include <flecsi/execution/hpx/internal_task.h>
+#endif
 
 ///
 // \file example_app.cc
@@ -20,89 +24,90 @@
 // \date Initial file creation: May 18, 2016
 ///
 
-namespace flecsi{
-namespace execution{
+namespace flecsi {
+namespace execution {
 //----------------------------------------------------------------------------//
-//Define MPI task
+// Define MPI task
 void
-mpi_task(double a)
-{ 
-  std::cout<<"inside MPI task"<<std::endl;
+mpi_task(double a) {
+  std::cout << "inside MPI task" << std::endl;
   int rank = 0;
   int size = 0;
-  
+
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &size);
   std::cout << "My rank: " << rank << std::endl;
-}//mpi_task
+} // mpi_task
 
-//register the task
+// register the task
 flecsi_register_mpi_task(mpi_task, flecsi::execution);
 
+#if FLECSI_RUNTIME_MODEL == FLECSI_RUNTIME_MODEL_legion
 //----------------------------------------------------------------------------//
 // Define internal Legion task to register.
-void internal_task_example_1(
-  const Legion::Task * task,                                 
-  const std::vector<Legion::PhysicalRegion> & regions,       
-  Legion::Context ctx,                                       
-  Legion::Runtime * runtime                         
-)
-{
-  std::cout <<"inside of the task1" <<std::endl;
+void
+internal_task_example_1(
+    const Legion::Task * task,
+    const std::vector<Legion::PhysicalRegion> & regions,
+    Legion::Context ctx,
+    Legion::Runtime * runtime) {
+  std::cout << "inside of the task1" << std::endl;
 } // internal_task_example
 
 // Register the task. The task id is automatically generated.
-__flecsi_internal_register_legion_task(internal_task_example_1,
-  flecsi::processor_type_t::loc, single);
+__flecsi_internal_register_legion_task(
+    internal_task_example_1,
+    flecsi::processor_type_t::loc,
+    single);
 
 //----------------------------------------------------------------------------//
 // Define internal Legion task to register.
-void internal_task_example_2(
-  const Legion::Task * task,                                 
-  const std::vector<Legion::PhysicalRegion> & regions,       
-  Legion::Context ctx,                                       
-  Legion::Runtime * runtime                         
-)
-{
-  std::cout <<"inside of the task2" <<std::endl;
+void
+internal_task_example_2(
+    const Legion::Task * task,
+    const std::vector<Legion::PhysicalRegion> & regions,
+    Legion::Context ctx,
+    Legion::Runtime * runtime) {
+  std::cout << "inside of the task2" << std::endl;
 } // internal_task_example
 
 // Register the task. The task id is automatically generated.
-__flecsi_internal_register_legion_task(internal_task_example_2,
-  flecsi::processor_type_t::loc, index);
+__flecsi_internal_register_legion_task(
+    internal_task_example_2,
+    flecsi::processor_type_t::loc,
+    index);
+#endif
 
 //----------------------------------------------------------------------------//
-//define FLeCSI task
-void task1() {
-  std::cout << "inside single task" <<std::endl;
+// define FLeCSI task
+void
+task1() {
+  std::cout << "inside single task" << std::endl;
 } // task1
 
-//register FLeCSI task
+// register FLeCSI task
 flecsi_register_task(task1, flecsi::execution, loc, single);
 
-void task2(){
-  std::cout<<"inside index task"<<std::endl;
+void
+task2() {
+  std::cout << "inside index task" << std::endl;
 }
 
 ////register FLeCSI task
 flecsi_register_task(task2, flecsi::execution, loc, index);
 
-
-
 //----------------------------------------------------------------------------//
-//Define Specialization Driver : a driver that gets executed at the top level
+// Define Specialization Driver : a driver that gets executed at the top level
 void
-specialization_tlt_init(
-  int argc,
-  char ** argv
-)
-{
+specialization_tlt_init(int argc, char ** argv) {
   context_t & context_ = context_t::instance();
   size_t task_key = utils::const_string_t{"specialization_driver"}.hash();
+#if FLECSI_RUNTIME_MODEL == FLECSI_RUNTIME_MODEL_legion
   auto runtime = Legion::Runtime::get_runtime();
   auto context = Legion::Runtime::get_context();
+#endif
 
-  std::cout<<"inside Specialization Driver"<<std::endl;
+  std::cout << "inside Specialization Driver" << std::endl;
 
   flecsi_execute_mpi_task(mpi_task, flecsi::execution, 0);
 
@@ -110,74 +115,70 @@ specialization_tlt_init(
 
   flecsi_execute_task(task2, flecsi::execution, index);
 
+#if FLECSI_RUNTIME_MODEL == FLECSI_RUNTIME_MODEL_legion
   auto key_1 = __flecsi_internal_task_key(internal_task_example_1);
   auto key_2 = __flecsi_internal_task_key(internal_task_example_2);
 
-  //executing internal legion tasks with pure legion calls
+  // executing internal legion tasks with pure legion calls
   Legion::TaskLauncher launcher(
-    context_t::instance().task_id(key_1),
-    LegionRuntime::HighLevel::TaskArgument(0,0));
-  auto f=runtime->execute_task(context, launcher);
+      context_t::instance().task_id(key_1),
+      LegionRuntime::HighLevel::TaskArgument(0, 0));
+  auto f = runtime->execute_task(context, launcher);
 
   Legion::ArgumentMap arg_map;
   Legion::IndexLauncher index_launcher(
-    context_t::instance().task_id(key_2),
-    Legion::Domain::from_rect<1>(context_t::instance().all_processes()),
-    Legion::TaskArgument(0, 0),
-    arg_map
-  );
+      context_t::instance().task_id(key_2),
+      Legion::Domain::from_rect<1>(context_t::instance().all_processes()),
+      Legion::TaskArgument(0, 0), arg_map);
 
- auto fm = runtime->execute_index_space(context, index_launcher);
- fm.wait_all_results();
+  auto fm = runtime->execute_index_space(context, index_launcher);
+  fm.wait_all_results();
+#endif
 
-}//specialization_driver
+} // specialization_driver
 
 //----------------------------------------------------------------------------//
 void
-driver(
-  int argc,
-  char ** argv
-)
-{
-  std::cout<<"inside Driver"<<std::endl;
+driver(int argc, char ** argv) {
+  std::cout << "inside Driver" << std::endl;
 
   flecsi_execute_task(task1, flecsi::execution, single);
-  
-  flecsi_execute_task(task2, flecsi::execution, index);
-}//driver
 
-}//namespace execution
-}//namespace flecsi
+  flecsi_execute_task(task2, flecsi::execution, index);
+} // driver
+
+} // namespace execution
+} // namespace flecsi
 
 //----------------------------------------------------------------------------//
 
-int main(int argc, char ** argv) {
-
+int
+main(int argc, char ** argv) {
 
 #ifdef GASNET_CONDUIT_MPI
-    int provided;
-    MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
-    // If you fail this assertion, then your version of MPI
-    // does not support calls from multiple threads and you
-    // cannot use the GASNet MPI conduit
-    if (provided < MPI_THREAD_MULTIPLE)
-      printf("ERROR: Your implementation of MPI does not support "
+  int provided;
+  MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+  // If you fail this assertion, then your version of MPI
+  // does not support calls from multiple threads and you
+  // cannot use the GASNet MPI conduit
+  if (provided < MPI_THREAD_MULTIPLE)
+    printf("ERROR: Your implementation of MPI does not support "
            "MPI_THREAD_MULTIPLE which is required for use of the "
            "GASNet MPI conduit with the Legion-MPI Interop!\n");
-    assert(provided == MPI_THREAD_MULTIPLE);
+  assert(provided == MPI_THREAD_MULTIPLE);
 #else
-std::cout <<"MPI MPI  MPI"<< std::endl;
-   MPI_Init(&argc, &argv);
+  std::cout << "MPI MPI  MPI" << std::endl;
+  MPI_Init(&argc, &argv);
 #endif
 
-  std::cout <<"taks and drivers exmple"<<std::endl;
+  std::cout << "tasks and drivers example" << std::endl;
 
   // Call FleCSI runtime initialization
   auto retval = flecsi::execution::context_t::instance().initialize(argc, argv);
 
 #ifndef GASNET_CONDUIT_MPI
   MPI_Finalize();
-#endif 
+#endif
 
   return retval;
 } // main

--- a/flecsi/coloring/CMakeLists.txt
+++ b/flecsi/coloring/CMakeLists.txt
@@ -6,8 +6,8 @@
 # /@@////   /@@/@@@@@@@/@@       ////////@@/@@
 # /@@       /@@/@@//// //@@    @@       /@@/@@
 # /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
-# //       ///  //////   //////  ////////  // 
-# 
+# //       ///  //////   //////  ////////  //
+#
 # Copyright (c) 2016 Los Alamos National Laboratory, LLC
 # All rights reserved
 #------------------------------------------------------------------------------#
@@ -51,6 +51,11 @@ elseif(FLECSI_RUNTIME_MODEL STREQUAL "mpi")
 
   set(UNIT_POLICY MPI)
   set(RUNTIME_DRIVER ../execution/mpi/runtime_driver.cc)
+
+elseif(FLECSI_RUNTIME_MODEL STREQUAL "hpx")
+
+  set(UNIT_POLICY HPX)
+  set(RUNTIME_DRIVER ../execution/hpx/runtime_driver.cc)
 
 endif()
 

--- a/flecsi/data/CMakeLists.txt
+++ b/flecsi/data/CMakeLists.txt
@@ -6,8 +6,8 @@
 # /@@////   /@@/@@@@@@@/@@       ////////@@/@@
 # /@@       /@@/@@//// //@@    @@       /@@/@@
 # /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
-# //       ///  //////   //////  ////////  // 
-# 
+# //       ///  //////   //////  ////////  //
+#
 # Copyright (c) 2016 Los Alamos National Laboratory, LLC
 # All rights reserved
 #------------------------------------------------------------------------------#
@@ -105,6 +105,26 @@ elseif(FLECSI_RUNTIME_MODEL STREQUAL "mpi")
 
   set(UNIT_POLICY MPI)
   set(RUNTIME_DRIVER ../execution/mpi/runtime_driver.cc)
+
+elseif(FLECSI_RUNTIME_MODEL STREQUAL "hpx")
+
+  set(data_HEADERS
+    ${data_HEADERS}
+    hpx/data_client_handle_policy.h
+    hpx/data_handle_policy.h
+    hpx/data_policy.h
+    hpx/dense.h
+    hpx/global.h
+    hpx/meta_data.h
+    hpx/registration_wrapper.h
+    hpx/scoped.h
+    hpx/sparse.h
+    hpx/storage_policy.h
+    hpx/tuple.h
+  )
+
+  set(UNIT_POLICY HPX)
+  set(RUNTIME_DRIVER ../execution/hpx/runtime_driver.cc)
 
 endif()
 

--- a/flecsi/data/data_client.h
+++ b/flecsi/data/data_client.h
@@ -16,6 +16,7 @@
 /*! @file */
 
 #include <flecsi/utils/common.h>
+#include <flecsi/utils/export_definitions.h>
 
 namespace flecsi {
 namespace data {
@@ -24,7 +25,8 @@ namespace data {
 //! Base type to identify types that allow data registration.
 //----------------------------------------------------------------------------//
 
-class data_client_t {
+class FLECSI_EXPORT data_client_t
+{
 public:
   /// Copy constructor (disabled)
   data_client_t(const data_client_t &) = delete;

--- a/flecsi/data/hpx/data_client_handle_policy.h
+++ b/flecsi/data/hpx/data_client_handle_policy.h
@@ -1,0 +1,29 @@
+/*~--------------------------------------------------------------------------~*
+ * Copyright (c) 2015 Los Alamos National Security, LLC
+ * All rights reserved.
+ *~--------------------------------------------------------------------------~*/
+
+#ifndef flecsi_data_hpx_data_client_handle_policy_h
+#define flecsi_data_hpx_data_client_handle_policy_h
+
+//----------------------------------------------------------------------------//
+//! @file
+//! @date Initial file creation: Jun 21, 2017
+//----------------------------------------------------------------------------//
+
+namespace flecsi {
+
+//----------------------------------------------------------------------------//
+//! FIXME: Description of class
+//----------------------------------------------------------------------------//
+
+struct hpx_data_client_handle_policy_t {}; // struct data_client_handle_policy_t
+
+} // namespace flecsi
+
+#endif // flecsi_data_hpx_data_client_handle_policy_h
+
+/*~-------------------------------------------------------------------------~-*
+ * Formatting options for vim.
+ * vim: set tabstop=2 shiftwidth=2 expandtab :
+ *~-------------------------------------------------------------------------~-*/

--- a/flecsi/data/hpx/data_handle_policy.h
+++ b/flecsi/data/hpx/data_handle_policy.h
@@ -1,0 +1,29 @@
+/*~--------------------------------------------------------------------------~*
+ * Copyright (c) 2015 Los Alamos National Security, LLC
+ * All rights reserved.
+ *~--------------------------------------------------------------------------~*/
+
+#ifndef flecsi_data_hpx_data_handle_policy_h
+#define flecsi_data_hpx_data_handle_policy_h
+
+///
+/// \file
+/// \date Initial file creation: Apr 04, 2017
+///
+
+namespace flecsi {
+
+///
+/// \class hpx_data_handle_policy_t data_handle_policy.h
+/// \brief hpx_data_handle_policy_t provides...
+///
+struct hpx_data_handle_policy_t {}; // class hpx_data_handle_policy_t
+
+} // namespace flecsi
+
+#endif // flecsi_data_hpx_data_handle_policy_h
+
+/*~-------------------------------------------------------------------------~-*
+ * Formatting options for vim.
+ * vim: set tabstop=2 shiftwidth=2 expandtab :
+ *~-------------------------------------------------------------------------~-*/

--- a/flecsi/data/hpx/data_policy.h
+++ b/flecsi/data/hpx/data_policy.h
@@ -1,0 +1,67 @@
+/*~--------------------------------------------------------------------------~*
+ * Copyright (c) 2015 Los Alamos National Security, LLC
+ * All rights reserved.
+ *~--------------------------------------------------------------------------~*/
+
+#ifndef flecsi_data_hpx_data_policy_h
+#define flecsi_data_hpx_data_policy_h
+
+//----------------------------------------------------------------------------//
+//! @file
+//! @date Initial file creation: Jun 21, 2017
+//----------------------------------------------------------------------------//
+
+#include "flecsi/data/hpx/registration_wrapper.h"
+#include "flecsi/data/storage.h"
+
+#include "flecsi/data/hpx/dense.h"
+#include "flecsi/data/hpx/global.h"
+#include "flecsi/data/hpx/scoped.h"
+#include "flecsi/data/hpx/sparse.h"
+#include "flecsi/data/hpx/tuple.h"
+
+namespace flecsi {
+namespace data {
+
+//----------------------------------------------------------------------------//
+//! FIXME: Description of class
+//----------------------------------------------------------------------------//
+
+struct hpx_data_policy_t {
+  template<size_t STORAGE_TYPE>
+  using storage_type__ = hpx::storage_type__<STORAGE_TYPE>;
+
+  template<
+      typename DATA_CLIENT_TYPE,
+      size_t STORAGE_TYPE,
+      typename DATA_TYPE,
+      size_t NAMESPACE_HASH,
+      size_t NAME_HASH,
+      size_t INDEX_SPACE,
+      size_t VERSIONS>
+  using field_wrapper__ = hpx_field_registration_wrapper__<
+      DATA_CLIENT_TYPE,
+      STORAGE_TYPE,
+      DATA_TYPE,
+      NAMESPACE_HASH,
+      NAME_HASH,
+      INDEX_SPACE,
+      VERSIONS>;
+
+  template<typename DATA_CLIENT_TYPE, size_t NAMESPACE_HASH, size_t NAME_HASH>
+  using client_wrapper__ = hpx_client_registration_wrapper__<
+      DATA_CLIENT_TYPE,
+      NAMESPACE_HASH,
+      NAME_HASH>;
+
+}; // class hpx_data_policy_t
+
+} // namespace data
+} // namespace flecsi
+
+#endif // flecsi_data_hpx_data_policy_h
+
+/*~-------------------------------------------------------------------------~-*
+ * Formatting options for vim.
+ * vim: set tabstop=2 shiftwidth=2 expandtab :
+ *~-------------------------------------------------------------------------~-*/

--- a/flecsi/data/hpx/dense.h
+++ b/flecsi/data/hpx/dense.h
@@ -1,0 +1,395 @@
+/*~--------------------------------------------------------------------------~*
+ *  @@@@@@@@  @@           @@@@@@   @@@@@@@@ @@
+ * /@@/////  /@@          @@////@@ @@////// /@@
+ * /@@       /@@  @@@@@  @@    // /@@       /@@
+ * /@@@@@@@  /@@ @@///@@/@@       /@@@@@@@@@/@@
+ * /@@////   /@@/@@@@@@@/@@       ////////@@/@@
+ * /@@       /@@/@@//// //@@    @@       /@@/@@
+ * /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
+ * //       ///  //////   //////  ////////  //
+ *
+ * Copyright (c) 2016 Los Alamos National Laboratory, LLC
+ * All rights reserved
+ *~--------------------------------------------------------------------------~*/
+
+#pragma once
+
+//----------------------------------------------------------------------------//
+// POLICY_NAMESPACE must be defined before including storage_type.h!!!
+// Using this approach allows us to have only one storage_type_t
+// definition that can be used by all data policies -> code reuse...
+#define POLICY_NAMESPACE hpx
+#include <flecsi/data/storage_class.h>
+#undef POLICY_NAMESPACE
+//----------------------------------------------------------------------------//
+
+#include <algorithm>
+#include <memory>
+
+#include <flecsi/data/common/data_types.h>
+#include <flecsi/data/common/privilege.h>
+#include <flecsi/data/data_client.h>
+#include <flecsi/data/dense_data_handle.h>
+#include <flecsi/execution/context.h>
+#include <flecsi/utils/const_string.h>
+#include <flecsi/utils/index_space.h>
+
+///
+/// \file
+/// \date Initial file creation: Apr 7, 2016
+///
+
+#define np(X)                                                                  \
+  std::cout << __FILE__ << ":" << __LINE__ << ": " << __PRETTY_FUNCTION__      \
+            << ": " << #X << " = " << (X) << std::endl
+
+namespace flecsi {
+namespace data {
+namespace hpx {
+
+//+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=//
+// Helper type definitions.
+//+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=//
+
+//----------------------------------------------------------------------------//
+// Dense handle.
+//----------------------------------------------------------------------------//
+
+//----------------------------------------------------------------------------//
+// Dense accessor.
+//----------------------------------------------------------------------------//
+
+///
+/// \brief dense_accessor_t provides logically array-based access to data
+///        variables that have been registered in the data model.
+///
+/// \tparam T The type of the data variable. If this type is not
+///           consistent with the type used to register the data, bad things
+///           can happen. However, it can be useful to reinterpret the type,
+///           e.g., when writing raw bytes. This class is part of the
+///           low-level \e flecsi interface, so it is assumed that you
+///           know what you are doing...
+/// \tparam MD The meta data type.
+///
+template<typename T, size_t EP, size_t SP, size_t GP>
+struct dense_handle_t : public dense_data_handle__<T, EP, SP, GP> {
+  //--------------------------------------------------------------------------//
+  // Type definitions.
+  //--------------------------------------------------------------------------//
+
+  using base = dense_data_handle__<T, EP, SP, GP>;
+
+  //--------------------------------------------------------------------------//
+  // Constructors.
+  //--------------------------------------------------------------------------//
+
+  // FIXME: calling to base class constructor?
+  ///
+  /// Default constructor.
+  ///
+  dense_handle_t() {}
+
+  ///
+  /// Copy constructor.
+  ///
+  dense_handle_t(const dense_handle_t & a) : label_(a.label_) {}
+
+  template<size_t EP2, size_t SP2, size_t GP2>
+  dense_handle_t(const dense_handle_t<T, EP2, SP2, GP2> & h)
+      : label_(h.label_) {}
+
+  //--------------------------------------------------------------------------//
+  // Member data interface.
+  //--------------------------------------------------------------------------//
+
+  ///
+  /// \brief Return a std::string containing the label of the data variable
+  ///       reference by this accessor.
+  ///
+  const std::string & label() const {
+    return label_;
+  } // label
+
+  ///
+  /// \brief Return the index space size of the data variable
+  ///        referenced by this accessor.
+  ///
+  size_t size() const {
+    return base::primary_size;
+  } // size
+
+  ///
+  // \brief Return the index space size of the data variable
+  //        referenced by this handle.
+  ///
+  size_t exclusive_size() const {
+    return base::exclusive_size;
+  } // size
+
+  ///
+  // \brief Return the index space size of the data variable
+  //        referenced by this handle.
+  ///
+  size_t shared_size() const {
+    return base::shared_size;
+  } // size
+
+  //--------------------------------------------------------------------------//
+  // Operators.
+  //--------------------------------------------------------------------------//
+
+  ///
+  /// \brief Provide logical array-based access to the data for this
+  ///        data variable.  This is the const operator version.
+  ///
+  /// \tparam E A complex index type.
+  ///
+  /// This version of the operator is provided to support use with
+  /// \e flecsi mesh entity types \ref mesh_entity_base_t.
+  ///
+  template<typename E>
+  const T & operator[](E * e) const {
+    return this->operator[](e->template id<0>());
+  } // operator []
+
+  ///
+  /// \brief Provide logical array-based access to the data for this
+  ///        data variable.  This is the const operator version.
+  ///
+  /// \tparam E A complex index type.
+  ///
+  /// This version of the operator is provided to support use with
+  /// \e flecsi mesh entity types \ref mesh_entity_base_t.
+  ///
+  template<typename E>
+  T & operator[](E * e) {
+    return this->operator[](e->template id<0>());
+  } // operator []
+
+  ///
+  /// \brief Provide logical array-based access to the data for this
+  ///        data variable.  This is the const operator version.
+  ///
+  /// \tparam E A complex index type.
+  ///
+  /// This version of the operator is provided to support use with
+  /// \e flecsi mesh entity types \ref mesh_entity_base_t.
+  ///
+  template<typename E>
+  const T & operator()(E * e) const {
+    return this->operator[](e->template id<0>());
+  } // operator []
+
+  ///
+  /// \brief Provide logical array-based access to the data for this
+  ///        data variable.  This is the const operator version.
+  ///
+  /// \tparam E A complex index type.
+  ///
+  /// This version of the operator is provided to support use with
+  /// \e flecsi mesh entity types \ref mesh_entity_base_t.
+  ///
+  template<typename E>
+  T & operator()(E * e) {
+    return this->operator[](e->template id<0>());
+  } // operator []
+
+  ///
+  // \brief Provide logical array-based access to the data for this
+  //        data variable.  This is the const operator version.
+  //
+  // \param index The index of the data variable to return.
+  ///
+  const T & operator[](size_t index) const {
+    assert(index < base::primary_size && "index out of range");
+    return base::primary_data[index];
+  } // operator []
+
+  ///
+  // \brief Provide logical array-based access to the data for this
+  //        data variable.  This is the const operator version.
+  //
+  // \param index The index of the data variable to return.
+  ///
+  T & operator[](size_t index) {
+    assert(index < base::primary_size && "index out of range");
+    return base::primary_data[index];
+  } // operator []
+
+  ///
+  // \brief Provide logical array-based access to the data for this
+  //        data variable.  This is the const operator version.
+  //
+  // \param index The index of the data variable to return.
+  ///
+  const T & exclusive(size_t index) const {
+    assert(index < base::exclusive_size && "index out of range");
+    return base::exclusive_data[index];
+  } // operator []
+
+  ///
+  // \brief Provide logical array-based access to the data for this
+  //        data variable.  This is the const operator version.
+  //
+  // \param index The index of the data variable to return.
+  ///
+  T & exclusive(size_t index) {
+    assert(index < base::exclusive_size && "index out of range");
+    return base::exclusive_data[index];
+  } // operator []
+
+  ///
+  // \brief Provide logical array-based access to the data for this
+  //        data variable.  This is the const operator version.
+  //
+  // \param index The index of the data variable to return.
+  ///
+  const T & shared(size_t index) const {
+    assert(index < base::shared_size && "index out of range");
+    return base::shared_data[index];
+  } // operator []
+
+  ///
+  // \brief Provide logical array-based access to the data for this
+  //        data variable.  This is the const operator version.
+  //
+  // \param index The index of the data variable to return.
+  ///
+  T & shared(size_t index) {
+    assert(index < base::shared_size && "index out of range");
+    return base::shared_data[index];
+  } // operator []
+
+  ///
+  // \brief Provide logical array-based access to the data for this
+  //        data variable.  This is the const operator version.
+  //
+  // \param index The index of the data variable to return.
+  ///
+  const T & ghost(size_t index) const {
+    assert(index < base::ghost_size && "index out of range");
+    return base::ghost_data[index];
+  } // operator []
+
+  ///
+  // \brief Provide logical array-based access to the data for this
+  //        data variable.  This is the const operator version.
+  //
+  // \param index The index of the data variable to return.
+  ///
+  T & ghost(size_t index) {
+    assert(index < base::ghost_size && "index out of range");
+    return base::ghost_data[index];
+  } // operator []
+
+  //  ///
+  //  // \brief Provide logical array-based access to the data for this
+  //  //        data variable.  This is the const operator version.
+  //  //
+  //  // \tparam E A complex index type.
+  //  //
+  //  // This version of the operator is provided to support use with
+  //  // \e flecsi mesh entity types \ref mesh_entity_base_t.
+  //  ///
+  //  template<typename E>
+  //  const T &
+  //  operator () (
+  //    E * e
+  //  ) const
+  //  {
+  //    return this->operator()(e->template id<0>());
+  //  } // operator ()
+  //
+  //  ///
+  //  // \brief Provide logical array-based access to the data for this
+  //  //        data variable.  This is the const operator version.
+  //  //
+  //  // \tparam E A complex index type.
+  //  //
+  //  // This version of the operator is provided to support use with
+  //  // \e flecsi mesh entity types \ref mesh_entity_base_t.
+  //  ///
+  //  template<typename E>
+  //  T &
+  //  operator () (
+  //    E * e
+  //  )
+  //  {
+  //    return this->operator()(e->template id<0>());
+  //  } // operator ()
+
+  ///
+  // \brief Provide logical array-based access to the data for this
+  //        data variable.  This is the const operator version.
+  //
+  // \param index The index of the data variable to return.
+  ///
+  const T & operator()(size_t index) const {
+    assert(index < base::primary_size && "index out of range");
+    return base::primary_data[index];
+  } // operator ()
+
+  ///
+  // \brief Provide logical array-based access to the data for this
+  //        data variable.  This is the const operator version.
+  //
+  // \param index The index of the data variable to return.
+  ///
+  T & operator()(size_t index) {
+    assert(index < base::primary_size && "index out of range");
+    return base::primary_data[index];
+  } // operator ()
+
+  ///
+  /// \brief Test to see if this accessor is empty
+  ///
+  /// \return true if registered.
+  ///
+  operator bool() const {
+    return base::primary_data != nullptr;
+  } // operator bool
+
+  template<typename, size_t, size_t, size_t>
+  friend struct dense_handle_t;
+
+private:
+  std::string label_ = "";
+}; // struct dense_handle_t
+
+//+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=//
+// Main type definition.
+//+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=//
+
+//----------------------------------------------------------------------------//
+// Dense storage type.
+//----------------------------------------------------------------------------//
+
+///
+/// FIXME: Dense storage type.
+///
+template<>
+struct storage_class__<dense> {
+  //--------------------------------------------------------------------------//
+  // Type definitions.
+  //--------------------------------------------------------------------------//
+
+  template<typename T, size_t EP, size_t SP, size_t GP>
+  using handle_t = dense_handle_t<T, EP, SP, GP>;
+
+  template<
+      typename DATA_CLIENT_TYPE,
+      typename DATA_TYPE,
+      size_t NAMESPACE,
+      size_t NAME,
+      size_t VERSION>
+  static handle_t<DATA_TYPE, 0, 0, 0>
+  get_handle(const data_client_t & data_client) {
+    handle_t<DATA_TYPE, 0, 0, 0> h;
+    return h;
+  }
+
+}; // struct storage_class__
+
+} // namespace hpx
+} // namespace data
+} // namespace flecsi

--- a/flecsi/data/hpx/global.h
+++ b/flecsi/data/hpx/global.h
@@ -1,0 +1,610 @@
+/*~--------------------------------------------------------------------------~*
+ *  @@@@@@@@  @@           @@@@@@   @@@@@@@@ @@
+ * /@@/////  /@@          @@////@@ @@////// /@@
+ * /@@       /@@  @@@@@  @@    // /@@       /@@
+ * /@@@@@@@  /@@ @@///@@/@@       /@@@@@@@@@/@@
+ * /@@////   /@@/@@@@@@@/@@       ////////@@/@@
+ * /@@       /@@/@@//// //@@    @@       /@@/@@
+ * /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
+ * //       ///  //////   //////  ////////  //
+ *
+ * Copyright (c) 2016 Los Alamos National Laboratory, LLC
+ * All rights reserved
+ *~--------------------------------------------------------------------------~*/
+
+#ifndef flecsi_hpx_global_h
+#define flecsi_hpx_global_h
+
+//----------------------------------------------------------------------------//
+// POLICY_NAMESPACE must be defined before including storage_type.h!!!
+// Using this approach allows us to have only one storage_type_t
+// definition that can be used by all data policies -> code reuse...
+#define POLICY_NAMESPACE hpx
+#include "flecsi/data/storage_type.h"
+#undef POLICY_NAMESPACE
+//----------------------------------------------------------------------------//
+
+#include "flecsi/data/data_client.h"
+#include "flecsi/data/data_handle.h"
+#include "flecsi/utils/const_string.h"
+
+#include <algorithm>
+
+///
+/// \file
+/// \date Initial file creation: Apr 17, 2016
+///
+
+namespace flecsi {
+namespace data {
+namespace hpx {
+
+//+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=//
+// Helper type definitions.
+//+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=//
+
+//----------------------------------------------------------------------------//
+// Scalar accessor.
+//----------------------------------------------------------------------------//
+
+///
+/// \brief global_accessor_t provides logically array-based access to data
+///        variables that have been registered in the data model.
+///
+/// \tparam T The type of the data variable. If this type is not
+///           consistent with the type used to register the data, bad things
+///           can happen. However, it can be useful to reinterpret the type,
+///           e.g., when writing raw bytes. This class is part of the
+///           low-level \e flecsi interface, so it is assumed that you
+///           know what you are doing...
+/// \tparam MD The meta data type.
+///
+template<typename T, typename MD>
+struct global_accessor_t {
+
+  //--------------------------------------------------------------------------//
+  // Type definitions.
+  //--------------------------------------------------------------------------//
+
+  using meta_data_t = MD;
+  using user_meta_data_t = typename meta_data_t::user_meta_data_t;
+
+  //--------------------------------------------------------------------------//
+  // Constructors.
+  //--------------------------------------------------------------------------//
+
+  /// Default constructor.
+  global_accessor_t() = default;
+
+  ///
+  /// Constructor.
+  ///
+  /// \param label The c_str() version of the const_string_t used for
+  ///              this data variable's hash.
+  /// \param size The size of the associated index space.
+  /// \param data A pointer to the raw data.
+  /// \param user_meta_data A reference to the user-defined meta data.
+  ///
+  global_accessor_t(
+      const std::string & label,
+      T * data,
+      const user_meta_data_t & user_meta_data,
+      bitset_t & user_attributes)
+      : label_(label), data_(data), user_meta_data_(&user_meta_data),
+        user_attributes_(&user_attributes) {}
+
+  ///
+  /// Copy constructor.
+  ///
+  global_accessor_t(const global_accessor_t & a)
+      : label_(a.label_), data_(a.data_), user_meta_data_(a.user_meta_data_),
+        user_attributes_(a.user_attributes_) {}
+
+  //--------------------------------------------------------------------------//
+  // Member data interface.
+  //--------------------------------------------------------------------------//
+
+  ///
+  /// \brief Return a std::string containing the label of the data variable
+  ///       reference by this accessor.
+  ///
+  const std::string & label() const {
+    return label_;
+  } // label
+
+  ///
+  /// \brief Return the user meta data for this data variable.
+  ///
+  const user_meta_data_t & meta_data() const {
+    return *user_meta_data_;
+  } // meta_data
+
+  ///
+  ///
+  ///
+  bitset_t & attributes() {
+    return *user_attributes_;
+  } // attributes
+
+  const bitset_t & attributes() const {
+    return *user_attributes_;
+  } // attributes
+
+  //--------------------------------------------------------------------------//
+  // Operators.
+  //--------------------------------------------------------------------------//
+
+  /// \brief copy operator.
+  /// \param [in] a  The accessor to copy.
+  /// \return A reference to the new copy.
+  global_accessor_t & operator=(const global_accessor_t & a) {
+    label_ = a.label_;
+    data_ = a.data_;
+    user_meta_data_ = a.user_meta_data_;
+    user_attributes_ = a.user_attributes_;
+    return *this;
+  } // operator =
+
+  ///
+  ///
+  ///
+  const T * operator->() const {
+    return data_;
+  } // operator ->
+
+  ///
+  ///
+  ///
+  T * operator->() {
+    return data_;
+  } // operator ->
+
+  ///  \brief Provide access to the data for this data variable.
+  ///  \remark This is the const operator version.
+  const T & operator*() const {
+    return *data_;
+  }
+
+  ///  \brief Provide access to the data for this data variable.
+  T & operator*() {
+    return *data_;
+  }
+
+  ///
+  /// \brief Test to see if this accessor is empty.
+  ///
+  /// \return true if registered.
+  ///
+  operator bool() const {
+    return data_ != nullptr;
+  } // operator bool
+
+  /// \brief Implicit conversion operator.
+  /// Using explicit keyword forces users to use static_cast<T>().  But
+  /// if you dont use this, then it is ambiguous
+  ///   accessor<int> a, b;
+  ///   int c = 2;
+  ///   a = c; // ok, uses assignment
+  ///   b = 3; // ok, uses assignement
+  ///   c = a; // ok for non-explicit cases, uses conversion operator
+  ///   c = static_cast<int>(a); // works for both explicit and implicit cases
+  ///   // which one do you want? accessor/accessor assignement operator or
+  ///   // do you want to convert b to int, then assign int to a?
+  ///   a = b;
+  /// Making this explicit forces you to have to static cast for all cases,
+  /// which I think is less ambiguous
+  ///   a = static_cast<int>(b);
+  ///   a = static_cast<int>(c);
+  explicit operator T() const {
+    return *data_;
+  }
+
+private:
+  std::string label_ = "";
+  T * data_ = nullptr;
+  const user_meta_data_t * user_meta_data_ = nullptr;
+  bitset_t * user_attributes_ = nullptr;
+
+}; // struct global_accessor_t
+
+//----------------------------------------------------------------------------//
+// Scalar handle.
+//----------------------------------------------------------------------------//
+
+template<typename T, size_t PS>
+struct global_handle_t {}; // struct global_handle_t
+
+//+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=//
+// Main type definition.
+//+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=//
+
+//----------------------------------------------------------------------------//
+// Scalar storage type.
+//----------------------------------------------------------------------------//
+
+///
+// FIXME: Scalar storage type.
+///
+template<typename DS, typename MD>
+struct storage_type_t<global, DS, MD> {
+
+  //--------------------------------------------------------------------------//
+  // Type definitions.
+  //--------------------------------------------------------------------------//
+
+  using data_store_t = DS;
+  using meta_data_t = MD;
+
+  template<typename T>
+  using accessor_t = global_accessor_t<T, MD>;
+
+  template<typename T, size_t PS>
+  using handle_t = global_handle_t<T, PS>;
+
+  using st_t = storage_type_t<global, DS, MD>;
+
+  //--------------------------------------------------------------------------//
+  // Data registration.
+  //--------------------------------------------------------------------------//
+
+  ///
+  /// \tparam T Data type to register.
+  /// \tparam NS Namespace.
+  /// \tparam Args Variadic arguments that are passed to
+  ///              metadata initialization.
+  ///
+  /// \param data_store A reference for accessing the low-level data.
+  /// \param key A const string instance containing the variable name.
+  /// \param runtime_namespace The runtime namespace to be used.
+  /// \param The number of variable versions for this datum.
+  ///
+  template<typename T, size_t NS, typename... Args>
+  static handle_t<T, 0> register_data(
+      const data_client_t & data_client,
+      data_store_t & data_store,
+      const utils::const_string_t & key,
+      size_t versions,
+      Args &&... args) {
+    size_t h = key.hash() ^ data_client.runtime_id();
+
+    // Runtime assertion that this key is unique.
+    assert(
+        data_store[NS].find(h) == data_store[NS].end() && "key already exists");
+
+    data_store[NS][h].user_data.initialize(std::forward<Args>(args)...);
+
+    data_store[NS][h].label = key.c_str();
+    data_store[NS][h].size = 1;
+    data_store[NS][h].type_size = sizeof(T);
+    data_store[NS][h].versions = versions;
+    data_store[NS][h].rtti.reset(new
+                                 typename meta_data_t::type_info_t(typeid(T)));
+
+    for (size_t i = 0; i < versions; ++i) {
+      data_store[NS][h].data[i].resize(sizeof(T));
+    } // for
+
+    // num_materials is unused for this storage type
+    data_store[NS][h].num_entries = 0;
+
+    return {};
+  } // register_data
+
+  //--------------------------------------------------------------------------//
+  // Data accessors.
+  //--------------------------------------------------------------------------//
+
+  /// \brief Return a global_accessor_t.
+  ///
+  /// \param [in] meta_data  The meta data to use to build the accessor.
+  /// \param [in] version   The version to select.
+  ///
+  /// \remark In this version, the search for meta data was already done.
+  template<typename T>
+  static accessor_t<T> get_accessor(meta_data_t & meta_data, size_t version) {
+
+    // check that the requested version exists
+    if (version >= meta_data.versions) {
+      std::cerr << "version out of range" << std::endl;
+      std::abort();
+    }
+
+    // construct an accessor from the meta data
+    return {meta_data.label, reinterpret_cast<T *>(&meta_data.data[version][0]),
+            meta_data.user_data, meta_data.attributes[version]};
+  }
+
+  /// \brief Return a global_accessor_t.
+  ///
+  /// \param [in] data_store   The data store to search.
+  /// \param [in] hash   The hash to search for.
+  /// \param [in] version   The version to select.
+  ///
+  /// \remark In this version, the search for meta data has not been done,
+  ///   but the key has already been hashed.
+  template<typename T, size_t NS>
+  static accessor_t<T> get_accessor(
+      data_store_t & data_store,
+      const utils::const_string_t::hash_type_t & hash,
+      size_t version) {
+    auto search = data_store[NS].find(hash);
+
+    if (search == data_store[NS].end()) {
+      return {};
+    } else {
+      return get_accessor<T>(search->second, version);
+    } // if
+  } // get_accessor
+
+  /// \brief Return a global_accessor_t.
+  ///
+  /// \param [in] data_client  The data client to restrict our search to.
+  /// \param [in] data_store   The data store to search.
+  /// \param [in] key   The key to search for.
+  /// \param [in] version   The version to select.
+  ///
+  /// \remark In this version, the search for meta data has not been done,
+  ///   and the key is still a string.
+  template<typename T, size_t NS>
+  static accessor_t<T> get_accessor(
+      const data_client_t & data_client,
+      data_store_t & data_store,
+      const utils::const_string_t & key,
+      size_t version) {
+    const size_t hash = key.hash() ^ data_client.runtime_id();
+    return get_accessor<T, NS>(data_store, hash, version);
+  } // get_accessor
+
+  /// \brief Return a list of all accessor_t's filtered by a predicate.
+  ///
+  /// \param [in] data_client  The data client to restrict our search to.
+  /// \param [in] data_store   The data store to search.
+  /// \param [in] version   The version to select.
+  /// \param [in] predicate   If \e predicate(a) returns true, add the accessor
+  ///                         to the list.
+  /// \param [in] sorted  If true, sort the results by label lexographically.
+  ///
+  /// \remark This version is confined to search within a single namespace
+  template<typename T, size_t NS, typename Predicate>
+  static decltype(auto) get_accessors(
+      const data_client_t & data_client,
+      data_store_t & data_store,
+      size_t version,
+      Predicate && predicate,
+      bool sorted) {
+
+    std::vector<accessor_t<T>> as;
+
+    // the runtime id
+    auto runtime_id = data_client.runtime_id();
+
+    // loop over each key pair
+    for (auto & entry_pair : data_store[NS]) {
+      // get the meta data key and label
+      const auto & meta_data_key = entry_pair.first;
+      auto & meta_data = entry_pair.second;
+      // now build the hash for this label
+      const auto & label = meta_data.label;
+      auto key_hash =
+          utils::hash<utils::const_string_t::hash_type_t>(label, label.size());
+      auto hash = key_hash ^ runtime_id;
+      // filter out the accessors for different data_clients
+      if (meta_data_key != hash)
+        continue;
+      // if the reconstructed hash matches the meta data key,
+      // then we may want this one
+      auto a = get_accessor<T>(meta_data, version);
+      if (a)
+        if (meta_data.rtti->type_info == typeid(T) && predicate(a))
+          as.emplace_back(std::move(a));
+    } // for
+
+    // if sorting is requested
+    if (sorted)
+      std::sort(as.begin(), as.end(), [](const auto & a, const auto & b) {
+        return a.label() < b.label();
+      });
+
+    return as;
+
+  } // get_accessor
+
+  /// \brief Return a list of all accessor_t's filtered by a predicate.
+  ///
+  /// \param [in] data_client  The data client to restrict our search to.
+  /// \param [in] data_store   The data store to search.
+  /// \param [in] version   The version to select.
+  /// \param [in] predicate   If \e predicate(a) returns true, add the accessor
+  ///                         to the list.
+  /// \param [in] sorted  If true, sort the results by label lexographically.
+  ///
+  /// \remark This version searches all namespaces.
+  template<typename T, typename Predicate>
+  static decltype(auto) get_accessors(
+      const data_client_t & data_client,
+      data_store_t & data_store,
+      size_t version,
+      Predicate && predicate,
+      bool sorted) {
+
+    std::vector<accessor_t<T>> as;
+
+    // the runtime id
+    auto runtime_id = data_client.runtime_id();
+
+    // check each namespace
+    for (auto & namespace_map : data_store) {
+
+      // the namespace data
+      auto & namespace_key = namespace_map.first;
+      auto & namespace_data = namespace_map.second;
+
+      // loop over each key pair
+      for (auto & entry_pair : namespace_data) {
+        // get the meta data key and label
+        const auto & meta_data_key = entry_pair.first;
+        auto & meta_data = entry_pair.second;
+        // now build the hash for this label
+        const auto & label = meta_data.label;
+        auto key_hash = utils::hash<utils::const_string_t::hash_type_t>(
+            label, label.size());
+        auto hash = key_hash ^ runtime_id;
+        // filter out the accessors for different data_clients
+        if (meta_data_key != hash)
+          continue;
+        // if the reconstructed hash matches the meta data key,
+        // then we may want this one
+        auto a = get_accessor<T>(meta_data, version);
+        if (a)
+          if (meta_data.rtti->type_info == typeid(T) && predicate(a))
+            as.emplace_back(std::move(a));
+      } // for each key pair
+    } // for each namespace
+
+    // if sorting is requested
+    if (sorted)
+      std::sort(as.begin(), as.end(), [](const auto & a, const auto & b) {
+        return a.label() < b.label();
+      });
+
+    return as;
+
+  } // get_accessor
+
+  /// \brief Return a list of all accessor_t's.
+  ///
+  /// \param [in] data_client  The data client to restrict our search to.
+  /// \param [in] data_store   The data store to search.
+  /// \param [in] version   The version to select.
+  /// \param [in] sorted  If true, sort the results by label lexographically.
+  ///
+  /// \remark This version is confined to search within a single namespace
+  template<typename T, size_t NS>
+  static decltype(auto) get_accessors(
+      const data_client_t & data_client,
+      data_store_t & data_store,
+      size_t version,
+      bool sorted) {
+
+    std::vector<accessor_t<T>> as;
+
+    // the runtime id
+    auto runtime_id = data_client.runtime_id();
+
+    // loop over each key pair
+    for (auto & entry_pair : data_store[NS]) {
+      // get the meta data key and label
+      const auto & meta_data_key = entry_pair.first;
+      auto & meta_data = entry_pair.second;
+      // now build the hash for this label
+      const auto & label = meta_data.label;
+      auto key_hash =
+          utils::hash<utils::const_string_t::hash_type_t>(label, label.size());
+      auto hash = key_hash ^ runtime_id;
+      // filter out the accessors for different data_clients
+      if (meta_data_key != hash)
+        continue;
+      // if the reconstructed hash matches the meta data key,
+      // then we may want this one
+      auto a = get_accessor<T>(meta_data, version);
+      if (a)
+        if (meta_data.rtti->type_info == typeid(T))
+          as.emplace_back(std::move(a));
+    } // for
+
+    // if sorting is requested
+    if (sorted)
+      std::sort(as.begin(), as.end(), [](const auto & a, const auto & b) {
+        return a.label() < b.label();
+      });
+
+    return as;
+
+  } // get_accessor
+
+  /// \brief Return a list of all accessor_t's.
+  ///
+  /// \param [in] data_client  The data client to restrict our search to.
+  /// \param [in] data_store   The data store to search.
+  /// \param [in] version   The version to select.
+  /// \param [in] sorted  If true, sort the results by label lexographically.
+  ///
+  /// \remark This version searches all namespaces.
+  template<typename T>
+  static decltype(auto) get_accessors(
+      const data_client_t & data_client,
+      data_store_t & data_store,
+      size_t version,
+      bool sorted) {
+
+    std::vector<accessor_t<T>> as;
+
+    // the runtime id
+    auto runtime_id = data_client.runtime_id();
+
+    // check each namespace
+    for (auto & namespace_map : data_store) {
+
+      // the namespace data
+      auto & namespace_key = namespace_map.first;
+      auto & namespace_data = namespace_map.second;
+
+      // loop over each key pair
+      for (auto & entry_pair : namespace_data) {
+        // get the meta data key and label
+        const auto & meta_data_key = entry_pair.first;
+        auto & meta_data = entry_pair.second;
+        // now build the hash for this label
+        const auto & label = meta_data.label;
+        auto key_hash = utils::hash<utils::const_string_t::hash_type_t>(
+            label, label.size());
+        auto hash = key_hash ^ runtime_id;
+        // filter out the accessors for different data_clients
+        if (meta_data_key != hash)
+          continue;
+        // if the reconstructed hash matches the meta data key,
+        // then we may want this one
+        auto a = get_accessor<T>(meta_data, version);
+        if (a)
+          if (meta_data.rtti->type_info == typeid(T))
+            as.emplace_back(std::move(a));
+      } // for each key pair
+    } // for each namespace
+
+    // if sorting is requested
+    if (sorted)
+      std::sort(as.begin(), as.end(), [](const auto & a, const auto & b) {
+        return a.label() < b.label();
+      });
+
+    return as;
+
+  } // get_accessor
+
+  //--------------------------------------------------------------------------//
+  // Data handles.
+  //--------------------------------------------------------------------------//
+
+  ///
+  ///
+  ///
+  template<typename T, size_t NS, size_t PS>
+  static handle_t<T, PS> get_handle(
+      const data_client_t & data_client,
+      data_store_t & data_store,
+      const utils::const_string_t & key) {
+    return {};
+  } // get_handle
+
+}; // struct storage_type_t
+
+} // namespace hpx
+} // namespace data
+} // namespace flecsi
+
+#endif // flecsi_hpx_global_h
+
+/*~-------------------------------------------------------------------------~-*
+ * Formatting options
+ * vim: set tabstop=2 shiftwidth=2 expandtab :
+ *~-------------------------------------------------------------------------~-*/

--- a/flecsi/data/hpx/meta_data.h
+++ b/flecsi/data/hpx/meta_data.h
@@ -1,0 +1,85 @@
+/*~--------------------------------------------------------------------------~*
+ *  @@@@@@@@  @@           @@@@@@   @@@@@@@@ @@
+ * /@@/////  /@@          @@////@@ @@////// /@@
+ * /@@       /@@  @@@@@  @@    // /@@       /@@
+ * /@@@@@@@  /@@ @@///@@/@@       /@@@@@@@@@/@@
+ * /@@////   /@@/@@@@@@@/@@       ////////@@/@@
+ * /@@       /@@/@@//// //@@    @@       /@@/@@
+ * /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
+ * //       ///  //////   //////  ////////  //
+ *
+ * Copyright (c) 2016 Los Alamos National Laboratory, LLC
+ * All rights reserved
+ *~--------------------------------------------------------------------------~*/
+
+#ifndef flecsi_hpx_meta_data_h
+#define flecsi_hpx_meta_data_h
+
+#include <memory>
+#include <typeinfo>
+#include <unordered_map>
+#include <vector>
+
+#include "flecsi/data/common/data_types.h"
+
+///
+/// \file
+/// \date Initial file creation: Apr 15, 2016
+///
+
+namespace flecsi {
+namespace data {
+
+//----------------------------------------------------------------------------//
+// struct hpx_meta_data_t
+//----------------------------------------------------------------------------//
+
+///
+/// \brief hpx_meta_data_t provides storage for extra information that is
+///        used to interpret data variable information at different points
+///        in the low-level runtime.
+///
+/// \tparam T A user-defined data type that will be carried with the meta data.
+///
+template<typename T>
+struct hpx_meta_data_t {
+  using user_meta_data_t = T;
+
+  std::string label;
+  user_meta_data_t user_data;
+  size_t index_space;
+  size_t size;
+  size_t type_size;
+  size_t versions;
+
+  ///
+  /// \brief type_info_t allows creation of reference information
+  ///        to the user-specified type of the data data.
+  ///
+  /// The std::type_info type requires dynamic initialization.  The
+  /// type_info_t type is designed to allow construction without
+  /// needing a non-trivial default constructor for the
+  /// hpx_meta_data_t type.
+  ///
+  struct type_info_t {
+    type_info_t(const std::type_info & type_info_) : type_info(type_info_) {}
+    const std::type_info & type_info;
+  }; // struct type_info_t
+
+  std::shared_ptr<type_info_t> rtti;
+
+  std::unordered_map<size_t, std::vector<uint8_t>> data;
+  std::unordered_map<size_t, bitset_t> attributes;
+  size_t num_entries;
+
+}; // struct hpx_meta_data_t
+
+} // namespace data
+} // namespace flecsi
+
+#endif // flecsi_hpx_meta_data_h
+
+/*~-------------------------------------------------------------------------~-*
+ * Formatting options
+ * vim: set tabstop=2 shiftwidth=2 expandtab :
+ *~-------------------------------------------------------------------------~-*/

--- a/flecsi/data/hpx/registration_wrapper.h
+++ b/flecsi/data/hpx/registration_wrapper.h
@@ -1,0 +1,91 @@
+/*~--------------------------------------------------------------------------~*
+ * Copyright (c) 2015 Los Alamos National Security, LLC
+ * All rights reserved.
+ *~--------------------------------------------------------------------------~*/
+
+#ifndef flecsi_data_hpx_registration_wrapper_h
+#define flecsi_data_hpx_registration_wrapper_h
+
+//----------------------------------------------------------------------------//
+//! @file
+//! @date Initial file creation: Apr 27, 2017
+//----------------------------------------------------------------------------//
+
+#include <cinchlog.h>
+
+#include "flecsi/execution/context.h"
+#include "flecsi/topology/mesh_topology.h"
+#include "flecsi/utils/tuple_walker.h"
+
+namespace flecsi {
+namespace data {
+
+//----------------------------------------------------------------------------//
+//!
+//----------------------------------------------------------------------------//
+
+template<
+    typename DATA_CLIENT_TYPE,
+    size_t STORAGE_TYPE,
+    typename DATA_TYPE,
+    size_t NAMESPACE_HASH,
+    size_t NAME_HASH,
+    size_t INDEX_SPACE,
+    size_t VERSIONS>
+struct hpx_field_registration_wrapper__ {
+  using field_id_t = size_t;
+
+  static void register_callback(field_id_t fid) {
+    clog(info) << "In register_callback" << std::endl;
+    // Do stuff
+  } // register_callback
+
+}; // class hpx_field_registration_wrapper_t
+
+///
+/// \class registration_wrapper_t registration_wrapper.h
+/// \brief registration_wrapper_t provides...
+///
+template<typename DATA_CLIENT_TYPE, size_t NAMESPACE_HASH, size_t NAME_HASH>
+struct hpx_client_registration_wrapper__ {
+}; // class hpx_client_registration_wrapper_t
+
+template<typename POLICY_TYPE, size_t NAMESPACE_HASH, size_t NAME_HASH>
+struct hpx_client_registration_wrapper__<
+    flecsi::topology::mesh_topology__<POLICY_TYPE>,
+    NAMESPACE_HASH,
+    NAME_HASH> {
+  using field_id_t = size_t;
+  // using mesh_topology_t = flecsi::topology::mesh_topology_t<POLICY_TYPE>;
+
+  static void register_callback(field_id_t fid) {
+    clog_tag_guard(registration);
+    clog(info) << "In client_register_callback" << std::endl;
+    // Do stuff
+  } // register_callback
+
+  template<typename TUPLE_ENTRY_TYPE>
+  struct type_walker__
+      : public flecsi::utils::tuple_walker__<type_walker__<TUPLE_ENTRY_TYPE>> {
+    void handle(TUPLE_ENTRY_TYPE const & entry) {
+      std::cout << "adding with domain: " << std::get<1>(entry) << std::endl;
+    } // handle
+  }; // struct type_walker__
+
+  static void register_data() {
+    // walk types
+    type_walker__<typename POLICY_TYPE::entity_types> type_wakler;
+
+  } // register_data
+
+}; // struct hpx_client_registration_wrapper_t
+
+} // namespace data
+} // namespace flecsi
+
+#endif // flecsi_data_hpx_registration_wrapper_h
+
+/*~-------------------------------------------------------------------------~-*
+ * Formatting options for vim.
+ * vim: set tabstop=2 shiftwidth=2 expandtab :
+ *~-------------------------------------------------------------------------~-*/

--- a/flecsi/data/hpx/scoped.h
+++ b/flecsi/data/hpx/scoped.h
@@ -1,0 +1,89 @@
+/*~--------------------------------------------------------------------------~*
+ *  @@@@@@@@  @@           @@@@@@   @@@@@@@@ @@
+ * /@@/////  /@@          @@////@@ @@////// /@@
+ * /@@       /@@  @@@@@  @@    // /@@       /@@
+ * /@@@@@@@  /@@ @@///@@/@@       /@@@@@@@@@/@@
+ * /@@////   /@@/@@@@@@@/@@       ////////@@/@@
+ * /@@       /@@/@@//// //@@    @@       /@@/@@
+ * /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
+ * //       ///  //////   //////  ////////  //
+ *
+ * Copyright (c) 2016 Los Alamos National Laboratory, LLC
+ * All rights reserved
+ *~--------------------------------------------------------------------------~*/
+
+#ifndef flecsi_hpx_scoped_h
+#define flecsi_hpx_scoped_h
+
+//----------------------------------------------------------------------------//
+// POLICY_NAMESPACE must be defined before including storage_type.h!!!
+// Using this approach allows us to have only one storage_type_t
+// definintion that can be used by all data policies -> code reuse...
+#define POLICY_NAMESPACE hpx
+#include "flecsi/data/storage_type.h"
+#undef POLICY_NAMESPACE
+//----------------------------------------------------------------------------//
+
+#include "flecsi/utils/const_string.h"
+
+///
+/// \file
+/// \date Initial file creation: Apr 17, 2016
+///
+
+namespace flecsi {
+namespace data {
+namespace hpx {
+
+///
+/// FIXME: Scoped storage type.
+///
+template<typename data_store_t, typename meta_data_t>
+struct storage_type_t<scoped, data_store_t, meta_data_t> {
+
+  struct scoped_accessor_t {}; // struct scoped_accessor_t
+
+  struct scoped_handle_t {}; // struct scoped_handle_t
+
+  template<typename T, size_t NS, typename... Args>
+  static decltype(auto) register_data(
+      data_store_t & data_store,
+      uintptr_t runtime_namespace,
+      const utils::const_string_t & key,
+      size_t indices,
+      Args &&... args) {} // register_data
+
+  ///
+  ///
+  ///
+  template<typename T, size_t NS>
+  static scoped_accessor_t get_accessor(
+      data_store_t & data_store,
+      uintptr_t runtime_namespace,
+      const utils::const_string_t & key) {
+    return {};
+  } // get_accessor
+
+  ///
+  ///
+  ///
+  template<typename T, size_t NS>
+  static scoped_handle_t get_handle(
+      data_store_t & data_store,
+      uintptr_t runtime_namespace,
+      const utils::const_string_t & key) {
+    return {};
+  } // get_handle
+
+}; // struct storage_type_t
+
+} // namespace hpx
+} // namespace data
+} // namespace flecsi
+
+#endif // flecsi_hpx_scoped_h
+
+/*~-------------------------------------------------------------------------~-*
+ * Formatting options
+ * vim: set tabstop=2 shiftwidth=2 expandtab :
+ *~-------------------------------------------------------------------------~-*/

--- a/flecsi/data/hpx/sparse.h
+++ b/flecsi/data/hpx/sparse.h
@@ -1,0 +1,678 @@
+/*~--------------------------------------------------------------------------~*
+ *  @@@@@@@@  @@           @@@@@@   @@@@@@@@ @@
+ * /@@/////  /@@          @@////@@ @@////// /@@
+ * /@@       /@@  @@@@@  @@    // /@@       /@@
+ * /@@@@@@@  /@@ @@///@@/@@       /@@@@@@@@@/@@
+ * /@@////   /@@/@@@@@@@/@@       ////////@@/@@
+ * /@@       /@@/@@//// //@@    @@       /@@/@@
+ * /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
+ * //       ///  //////   //////  ////////  //
+ *
+ * Copyright (c) 2016 Los Alamos National Laboratory, LLC
+ * All rights reserved
+ *~--------------------------------------------------------------------------~*/
+
+#ifndef flecsi_hpx_sparse_h
+#define flecsi_hpx_sparse_h
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <set>
+#include <unordered_set>
+
+//----------------------------------------------------------------------------//
+// POLICY_NAMESPACE must be defined before including storage_type.h!!!
+// Using this approach allows us to have only one storage_type_t
+// definintion that can be used by all data policies -> code reuse...
+#define POLICY_NAMESPACE hpx
+#include "flecsi/data/storage_type.h"
+#undef POLICY_NAMESPACE
+//----------------------------------------------------------------------------//
+
+#include "flecsi/topology/index_space.h"
+#include "flecsi/utils/const_string.h"
+
+#define np(X)                                                                  \
+  std::cout << __FILE__ << ":" << __LINE__ << ": " << __PRETTY_FUNCTION__      \
+            << ": " << #X << " = " << (X) << std::endl
+
+///
+/// \file
+/// \date Initial file creation: Apr 17, 2016
+///
+
+namespace flecsi {
+namespace data {
+namespace hpx {
+
+//+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=//
+// Helper type definitions.
+//+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=//
+
+//----------------------------------------------------------------------------//
+// Sparse accessor.
+//----------------------------------------------------------------------------//
+
+///
+///
+///
+template<typename T>
+struct entry_value__ {
+  entry_value__(size_t entry) : entry(entry) {}
+
+  entry_value__(size_t entry, T value) : entry(entry), value(value) {}
+
+  entry_value__() {}
+
+  size_t entry;
+  T value;
+}; // struct entry_value__
+
+static constexpr size_t INDICES_FLAG = 1UL << 63;
+static constexpr size_t ENTRIES_FLAG = 1UL << 62;
+
+///
+/// \brief sparse_accessor_t provides logically array-based access to data
+///        variables that have been registered in the data model.
+///
+/// \tparam T The type of the data variable. If this type is not
+///           consistent with the type used to register the data, bad things
+///           can happen. However, it can be useful to reinterpret the type,
+///           e.g., when writing raw bytes. This class is part of the
+///           low-level \e flecsi interface, so it is assumed that you
+///           know what you are doing...
+/// \tparam MD The meta data type.
+///
+template<typename T, typename MD>
+struct sparse_accessor_t {
+  //--------------------------------------------------------------------------//
+  // Type definitions.
+  //--------------------------------------------------------------------------//
+
+  using iterator_t = utils::index_space_t::iterator_t;
+  using meta_data_t = MD;
+  using user_meta_data_t = typename meta_data_t::user_meta_data_t;
+
+  using entry_value_t = entry_value__<T>;
+
+  using index_space_ =
+      topology::index_space<topology::simple_entry<size_t>, true>;
+
+  //--------------------------------------------------------------------------//
+  // Constructors.
+  //--------------------------------------------------------------------------//
+
+  ///
+  ///
+  ///
+  sparse_accessor_t() {}
+
+  ///
+  ///
+  ///
+  sparse_accessor_t(meta_data_t & meta_data, size_t version)
+      : meta_data_(meta_data), version_(version), num_indices_(meta_data.size),
+        num_entries_(meta_data_.num_entries) {
+    auto iitr = meta_data_.data.find(version | INDICES_FLAG);
+    assert(iitr != meta_data_.data.end());
+
+    std::vector<uint8_t> & raw_indices =
+        const_cast<std::vector<uint8_t> &>(iitr->second);
+
+    indices_ = reinterpret_cast<size_t *>(&raw_indices[0]);
+
+    auto mitr = meta_data_.data.find(version | ENTRIES_FLAG);
+    assert(mitr != meta_data_.data.end());
+
+    std::vector<uint8_t> & raw_entries =
+        const_cast<std::vector<uint8_t> &>(mitr->second);
+
+    entries_ = reinterpret_cast<entry_value_t *>(&raw_entries[0]);
+  } // sparse_accessor_t
+
+  //--------------------------------------------------------------------------//
+  // Member data interface.
+  //--------------------------------------------------------------------------//
+
+  ///
+  ///
+  ///
+  bitset_t & attributes() {
+    return meta_data_.user_attributes_;
+  } // attributes
+
+  //--------------------------------------------------------------------------//
+  // Operators.
+  //--------------------------------------------------------------------------//
+
+  ///
+  ///
+  ///
+  T & operator()(size_t index, size_t entry) {
+    assert(index < num_indices_ && "sparse accessor: index out of bounds");
+
+    entry_value_t * start = entries_ + indices_[index];
+    entry_value_t * end = entries_ + indices_[index + 1];
+
+    entry_value_t * itr = std::lower_bound(
+        start, end, entry_value_t(entry),
+        [](const auto & k1, const auto & k2) -> bool {
+          return k1.entry < k2.entry;
+        });
+
+    assert(itr != end && "sparse accessor: unmapped entry");
+
+    return itr->value;
+  } // operator ()
+
+  index_space_ entries() const {
+    size_t id = 0;
+    index_space_ is;
+    std::unordered_set<size_t> found;
+
+    for (size_t index = 0; index < num_indices_; ++index) {
+      entry_value_t * itr = entries_ + indices_[index];
+      entry_value_t * end = entries_ + indices_[index + 1];
+
+      while (itr != end) {
+        size_t entry = itr->entry;
+        if (found.find(entry) == found.end()) {
+          is.push_back({id++, entry});
+          found.insert(entry);
+        }
+        ++itr;
+      }
+    }
+
+    return is;
+  }
+
+  index_space_ entries(size_t index) const {
+    assert(index < num_indices_ && "sparse accessor: index out of bounds");
+
+    entry_value_t * itr = entries_ + indices_[index];
+    entry_value_t * end = entries_ + indices_[index + 1];
+
+    index_space_ is;
+
+    size_t id = 0;
+    while (itr != end) {
+      is.push_back({id++, itr->entry});
+      ++itr;
+    }
+
+    return is;
+  }
+
+  index_space_ indices() {
+    index_space_ is;
+    size_t id = 0;
+
+    for (size_t i = 0; i < num_indices_; ++i) {
+      if (indices_[i] != indices_[i + 1]) {
+        is.push_back({id++, i});
+      }
+    }
+
+    return is;
+  }
+
+  index_space_ indices(size_t entry) {
+    index_space_ is;
+    size_t id = 0;
+
+    for (size_t index = 0; index < num_indices_; ++index) {
+      entry_value_t * start = entries_ + indices_[index];
+      entry_value_t * end = entries_ + indices_[index + 1];
+
+      if (std::binary_search(
+              start, end, entry_value_t(entry),
+              [](const auto & k1, const auto & k2) -> bool {
+                return k1.entry < k2.entry;
+              })) {
+        is.push_back({id++, index});
+      }
+    }
+
+    return is;
+  }
+
+  ///
+  ///
+  ///
+  void dump() {
+    for (size_t i = 0; i < num_indices_; ++i) {
+      size_t start = indices_[i];
+      size_t end = indices_[i + 1];
+
+      std::cout << "+++++ row: " << i << std::endl;
+
+      for (size_t j = start; j < end; ++j) {
+        entry_value_t & mj = entries_[j];
+        std::cout << "++ entry: " << mj.entry << std::endl;
+        std::cout << "++ value: " << mj.value << std::endl << std::endl;
+      } // for
+    } // for
+  } // dump
+
+  ///
+  ///
+  ///
+  T * data() {
+    return nullptr;
+  } // data
+
+private:
+  size_t version_;
+  const meta_data_t & meta_data_ = *(std::make_unique<meta_data_t>());
+  size_t num_indices_;
+  size_t num_entries_;
+  size_t * indices_;
+  entry_value_t * entries_;
+
+}; // struct sparse_accessor_t
+
+template<typename T, typename MD>
+struct sparse_mutator_t {
+
+  //--------------------------------------------------------------------------//
+  // Type definitions.
+  //--------------------------------------------------------------------------//
+
+  using iterator_t = utils::index_space_t::iterator_t;
+  using meta_data_t = MD;
+  using user_meta_data_t = typename meta_data_t::user_meta_data_t;
+
+  using entry_value_t = entry_value__<T>;
+
+  //--------------------------------------------------------------------------//
+  // Constructors.
+  //--------------------------------------------------------------------------//
+
+  ///
+  ///
+  ///
+  sparse_mutator_t() {}
+
+  ///
+  ///
+  ///
+  sparse_mutator_t(
+      size_t num_slots,
+      const std::string & label,
+      size_t version,
+      meta_data_t & meta_data,
+      const user_meta_data_t & user_meta_data)
+      : num_slots_(num_slots), label_(label), version_(version),
+        meta_data_(meta_data), num_indices_(meta_data_.size),
+        num_entries_(meta_data_.num_entries),
+        indices_(new size_t[num_indices_]),
+        entries_(new entry_value_t[num_indices_ * num_slots_]),
+        erase_set_(nullptr) {
+    for (size_t i = 0; i < num_indices_; ++i) {
+      indices_[i] = 0;
+    }
+  }
+
+  ///
+  ///
+  ///
+  ~sparse_mutator_t() {
+    commit();
+  } // ~sparse_mutator_t
+
+  T & operator()(size_t index, size_t entry) {
+    assert(indices_ && "sparse mutator has alread been committed");
+    assert(index < num_indices_ && entry < num_entries_);
+
+    size_t n = indices_[index];
+
+    if (n >= num_slots_) {
+      return spare_map_.emplace(index, entry_value_t(entry))->second.value;
+    } // if
+
+    entry_value_t * start = entries_ + index * num_slots_;
+    entry_value_t * end = start + n;
+
+    entry_value_t * itr = std::lower_bound(
+        start, end, entry_value_t(entry),
+        [](const auto & k1, const auto & k2) -> bool {
+          return k1.entry < k2.entry;
+        });
+
+    // if we are creating an that has already been created, just
+    // over-write the value and exit.  No need to increment the
+    // counters or move data.
+    if (itr != end && itr->entry == entry) {
+      return itr->value;
+    }
+
+    while (end != itr) {
+      *(end) = *(end - 1);
+      --end;
+    } // while
+
+    itr->entry = entry;
+
+    ++indices_[index];
+
+    return itr->value;
+  } // operator ()
+
+  void erase(size_t index, size_t entry) {
+    assert(indices_ && "sparse mutator has alread been committed");
+    assert(index < num_indices_ && entry < num_entries_);
+
+    if (!erase_set_) {
+      erase_set_ = new erase_set_t;
+    }
+
+    erase_set_->emplace(std::make_pair(index, entry));
+  }
+
+  T * data() {
+    return nullptr;
+  } // data
+
+  void commit() {
+    if (!indices_) {
+      return;
+    } // if
+
+    auto iitr = meta_data_.data.find(version_ | INDICES_FLAG);
+    assert(iitr != meta_data_.data.end());
+
+    std::vector<uint8_t> & raw_indices =
+        const_cast<std::vector<uint8_t> &>(iitr->second);
+
+    size_t * indices = reinterpret_cast<size_t *>(&raw_indices[0]);
+
+    auto mitr = meta_data_.data.find(version_ | ENTRIES_FLAG);
+    assert(mitr != meta_data_.data.end());
+
+    std::vector<uint8_t> & raw_entries =
+        const_cast<std::vector<uint8_t> &>(mitr->second);
+
+    constexpr size_t ev_bytes = sizeof(entry_value_t);
+
+    size_t s = raw_entries.size();
+    size_t c = raw_entries.capacity();
+    size_t d = (num_indices_ * num_slots_ + spare_map_.size()) * ev_bytes;
+
+    if (c - s < d) {
+      // raw_entries.reserve(c * ev_bytes + d);
+      raw_entries.resize(c * ev_bytes + d);
+    } // if
+
+    entry_value_t * entries =
+        reinterpret_cast<entry_value_t *>(&raw_entries[0]);
+
+    entry_value_t * entries_end = entries + s / ev_bytes;
+
+    for (size_t i = 0; i < num_indices_; ++i) {
+      size_t n = indices_[i];
+
+      size_t pos = indices[i];
+
+      if (n == 0) {
+        indices[i + 1] = pos;
+        continue;
+      } // if
+
+      auto p = spare_map_.equal_range(i);
+
+      size_t m = distance(p.first, p.second);
+
+      entry_value_t * start = entries_ + i * num_slots_;
+      entry_value_t * end = start + n;
+
+      auto iitr = entries + pos;
+
+      std::copy(iitr, entries_end, iitr + n + m);
+      std::copy(start, end, iitr);
+      entries_end += n + m;
+
+      auto cmp = [](const auto & k1, const auto & k2) -> bool {
+        return k1.entry < k2.entry;
+      };
+
+      auto nitr = iitr + indices[i + 1];
+
+      std::inplace_merge(iitr, nitr, nitr + n, cmp);
+
+      if (m == 0) {
+        indices[i + 1] = pos + n;
+        continue;
+      } // if
+
+      indices[i + 1] = pos + n + m;
+
+      auto vitr = nitr + n;
+
+      for (auto itr = p.first; itr != p.second; ++itr) {
+        vitr->entry = itr->second.entry;
+        vitr->value = itr->second.value;
+        ++vitr;
+      } // for
+
+      std::inplace_merge(iitr, nitr + n, nitr + n + m, cmp);
+    } // for
+
+    delete[] indices_;
+    indices_ = nullptr;
+
+    delete[] entries_;
+    entries_ = nullptr;
+
+    if (!erase_set_) {
+      return;
+    }
+
+    constexpr size_t erased_marker = std::numeric_limits<size_t>::max();
+
+    entry_value_t * start;
+    entry_value_t * end;
+
+    size_t last = std::numeric_limits<size_t>::max();
+
+    size_t num_erased = 0;
+
+    for (auto p : *erase_set_) {
+      if (p.first != last) {
+        start = entries + indices[p.first];
+        end = entries + indices[p.first + 1];
+        last = p.first;
+        indices[p.first] -= num_erased;
+      }
+
+      entry_value_t * m = std::lower_bound(
+          start, end, entry_value_t(p.second),
+          [](const auto & k1, const auto & k2) -> bool {
+            return k1.entry < k2.entry;
+          });
+
+      m->entry = erased_marker;
+      start = m + 1;
+      ++num_erased;
+    }
+
+    while (last < num_indices_) {
+      indices[++last] -= num_erased;
+    }
+
+    std::remove_if(entries, entries_end, [](const auto & k) -> bool {
+      return k.entry == erased_marker;
+    });
+
+    s = raw_entries.size();
+    s -= num_erased * ev_bytes;
+    raw_entries.resize(s);
+
+    delete erase_set_;
+    erase_set_ = nullptr;
+  } // commit
+
+private:
+  using spare_map_t = std::multimap<size_t, entry_value__<T>>;
+  using erase_set_t = std::set<std::pair<size_t, size_t>>;
+
+  size_t num_slots_;
+  std::string label_ = "";
+  size_t version_ = 0;
+  const meta_data_t & meta_data_ = *(std::make_unique<meta_data_t>());
+
+  size_t num_indices_;
+  size_t num_entries_;
+  size_t * indices_;
+  entry_value__<T> * entries_;
+  spare_map_t spare_map_;
+  erase_set_t * erase_set_;
+}; // struct sparse_accessor_t
+
+//----------------------------------------------------------------------------//
+// Sparse handle.
+//----------------------------------------------------------------------------//
+
+template<typename T>
+struct sparse_handle_t {}; // struct sparse_handle_t
+
+//+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=//
+// Main type definition.
+//+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=//
+
+///
+// FIXME: Sparse storage type.
+///
+template<typename DS, typename MD>
+struct storage_type_t<sparse, DS, MD> {
+
+  //--------------------------------------------------------------------------//
+  // Type definitions.
+  //--------------------------------------------------------------------------//
+
+  using data_store_t = DS;
+  using meta_data_t = MD;
+
+  template<typename T>
+  using accessor_t = sparse_accessor_t<T, MD>;
+
+  template<typename T>
+  using mutator_t = sparse_mutator_t<T, MD>;
+
+  template<typename T>
+  using handle_t = sparse_handle_t<T>;
+
+  //--------------------------------------------------------------------------//
+  // Data registration.
+  //--------------------------------------------------------------------------//
+
+  template<typename T, size_t NS, typename... Args>
+  static handle_t<T> register_data(
+      const data_client_t & data_client,
+      data_store_t & data_store,
+      const utils::const_string_t & key,
+      size_t versions,
+      size_t index_space,
+      size_t num_entries,
+      Args &&... args) {
+    size_t h = key.hash() ^ data_client.runtime_id();
+
+    // Runtime assertion that this key is unique
+    assert(
+        data_store[NS].find(h) == data_store[NS].end() && "key already exists");
+
+    meta_data_t & md = data_store[NS][h];
+
+    md.user_data.initialize(std::forward<Args>(args)...);
+    md.label = key.c_str();
+    md.size = data_client.indices(index_space);
+    md.type_size = sizeof(T);
+    md.versions = versions;
+    md.rtti.reset(new typename meta_data_t::type_info_t(typeid(T)));
+
+    md.num_entries = num_entries;
+
+    for (size_t version = 0; version < versions; ++version) {
+      auto & iv = md.data[version | INDICES_FLAG] = std::vector<uint8_t>();
+      iv.resize((data_client.indices(index_space) + 1) * sizeof(size_t));
+
+      md.data[version | ENTRIES_FLAG] = std::vector<uint8_t>();
+    }
+
+    return {};
+  } // register_data
+
+  ///
+  ///
+  ///
+  template<typename T, size_t NS>
+  static accessor_t<T> get_accessor(
+      const data_client_t & data_client,
+      data_store_t & data_store,
+      const utils::const_string_t & key,
+      size_t version) {
+    const size_t h = key.hash() ^ data_client.runtime_id();
+    auto search = data_store[NS].find(h);
+
+    if (search == data_store[NS].end()) {
+      return {};
+    } else {
+      auto & meta_data = search->second;
+
+      // check that the requested version exists
+      assert(meta_data.versions > version && "version out-of-range");
+
+      return {meta_data, version};
+    } // if
+  } // get_accessor
+
+  ///
+  ///
+  ///
+  template<typename T, size_t NS>
+  static mutator_t<T> get_mutator(
+      const data_client_t & data_client,
+      data_store_t & data_store,
+      const utils::const_string_t & key,
+      size_t slots,
+      size_t version) {
+    const size_t h = key.hash() ^ data_client.runtime_id();
+    auto search = data_store[NS].find(h);
+
+    if (search == data_store[NS].end()) {
+      return {};
+    } else {
+      auto & meta_data = search->second;
+
+      // check that the requested version exists
+      assert(meta_data.versions > version && "version out-of-range");
+
+      return {slots, meta_data.label, version, meta_data, meta_data.user_data};
+    } // if
+  } // get_accessor
+
+  ///
+  ///
+  ///
+  template<typename T, size_t NS>
+  static handle_t<T> get_handle(
+      const data_client_t & data_client,
+      data_store_t & data_store,
+      const utils::const_string_t & key,
+      size_t version) {
+    return {};
+  } // get_handle
+
+}; // struct storage_type_t
+
+} // namespace hpx
+} // namespace data
+} // namespace flecsi
+
+#endif // flecsi_hpx_sparse_h
+
+/*~-------------------------------------------------------------------------~-*
+ * Formatting options
+ * vim: set tabstop=2 shiftwidth=2 expandtab :
+ *~-------------------------------------------------------------------------~-*/

--- a/flecsi/data/hpx/storage_policy.h
+++ b/flecsi/data/hpx/storage_policy.h
@@ -1,0 +1,91 @@
+/*~--------------------------------------------------------------------------~*
+ *  @@@@@@@@  @@           @@@@@@   @@@@@@@@ @@
+ * /@@/////  /@@          @@////@@ @@////// /@@
+ * /@@       /@@  @@@@@  @@    // /@@       /@@
+ * /@@@@@@@  /@@ @@///@@/@@       /@@@@@@@@@/@@
+ * /@@////   /@@/@@@@@@@/@@       ////////@@/@@
+ * /@@       /@@/@@//// //@@    @@       /@@/@@
+ * /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
+ * //       ///  //////   //////  ////////  //
+ *
+ * Copyright (c) 2016 Los Alamos National Laboratory, LLC
+ * All rights reserved
+ *~--------------------------------------------------------------------------~*/
+
+#ifndef flecsi_hpx_storage_policy_h
+#define flecsi_hpx_storage_policy_h
+
+#include <cassert>
+#include <memory>
+#include <typeinfo>
+#include <unordered_map>
+#include <vector>
+
+#include "flecsi/data/common/data_hash.h"
+
+#include "flecsi/data/data_constants.h"
+#include "flecsi/data/hpx/meta_data.h"
+#include "flecsi/data/hpx/registration_wrapper.h"
+
+// Include partial specializations
+//#include "flecsi/data/hpx/global.h"
+#include "flecsi/data/hpx/dense.h"
+//#include "flecsi/data/hpx/sparse.h"
+//#include "flecsi/data/hpx/scoped.h"
+//#include "flecsi/data/hpx/tuple.h"
+
+///
+/// \file
+/// \date Initial file creation: Apr 17, 2016
+///
+
+namespace flecsi {
+namespace data {
+
+struct hpx_storage_policy_t {
+
+  using field_id_t = size_t;
+  using registration_function_t = std::function<void(size_t)>;
+  using data_value_t = std::pair<field_id_t, registration_function_t>;
+  using field_entry_t = std::unordered_map<size_t, data_value_t>;
+
+  // Field and client registration interfaces are the same for now.
+  using client_entry_t = field_entry_t;
+
+  bool register_field(
+      size_t client_key,
+      size_t key,
+      const registration_function_t & callback) {
+    // TODO:
+  }
+
+  void register_all() {
+    for (auto & c : field_registry_) {
+      for (auto & d : c.second) {
+        d.second.second(d.second.first);
+      } // for
+    } // for
+  } // register_all
+
+  auto const & field_registry() const {
+    return field_registry_;
+  } // field_registry
+
+  auto const & client_registry() const {
+    return client_registry_;
+  } // client_registry
+
+private:
+  std::unordered_map<size_t, field_entry_t> field_registry_;
+  std::unordered_map<size_t, client_entry_t> client_registry_;
+}; // struct hpx_storage_policy_t
+
+} // namespace data
+} // namespace flecsi
+
+#endif // flecsi_hpx_storage_policy_h
+
+/*~-------------------------------------------------------------------------~-*
+ * Formatting options
+ * vim: set tabstop=2 shiftwidth=2 expandtab :
+ *~-------------------------------------------------------------------------~-*/

--- a/flecsi/data/hpx/tuple.h
+++ b/flecsi/data/hpx/tuple.h
@@ -1,0 +1,90 @@
+/*~--------------------------------------------------------------------------~*
+ *  @@@@@@@@  @@           @@@@@@   @@@@@@@@ @@
+ * /@@/////  /@@          @@////@@ @@////// /@@
+ * /@@       /@@  @@@@@  @@    // /@@       /@@
+ * /@@@@@@@  /@@ @@///@@/@@       /@@@@@@@@@/@@
+ * /@@////   /@@/@@@@@@@/@@       ////////@@/@@
+ * /@@       /@@/@@//// //@@    @@       /@@/@@
+ * /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
+ * //       ///  //////   //////  ////////  //
+ *
+ * Copyright (c) 2016 Los Alamos National Laboratory, LLC
+ * All rights reserved
+ *~--------------------------------------------------------------------------~*/
+
+#ifndef flecsi_hpx_tuple_h
+#define flecsi_hpx_tuple_h
+
+//----------------------------------------------------------------------------//
+// POLICY_NAMESPACE must be defined before including storage_type.h!!!
+// Using this approach allows us to have only one storage_type_t
+// definintion that can be used by all data policies -> code reuse...
+#define POLICY_NAMESPACE hpx
+#include "flecsi/data/storage_type.h"
+#undef POLICY_NAMESPACE
+//----------------------------------------------------------------------------//
+
+#include "flecsi/utils/const_string.h"
+
+///
+// \file hpx/tuple.h
+// \authors bergen
+// \date Initial file creation: Apr 17, 2016
+///
+
+namespace flecsi {
+namespace data {
+namespace hpx {
+
+///
+// FIXME: Tuple storage type.
+///
+template<typename data_store_t, typename meta_data_t>
+struct storage_type_t<tuple, data_store_t, meta_data_t> {
+
+  struct tuple_accessor_t {}; // struct tuple_accessor_t
+
+  struct tuple_handle_t {}; // struct tuple_handle_t
+
+  template<typename T, size_t NS, typename... Args>
+  static decltype(auto) register_data(
+      data_store_t & data_store,
+      uintptr_t runtime_namespace,
+      const utils::const_string_t & key,
+      size_t indices,
+      Args &&... args) {} // register_data
+
+  ///
+  //
+  ///
+  template<typename T, size_t NS>
+  static tuple_accessor_t get_accessor(
+      data_store_t & data_store,
+      uintptr_t runtime_namespace,
+      const utils::const_string_t & key) {
+    return {};
+  } // get_accessor
+
+  ///
+  //
+  ///
+  template<typename T, size_t NS>
+  static tuple_handle_t get_handle(
+      data_store_t & data_store,
+      uintptr_t runtime_namespace,
+      const utils::const_string_t & key) {
+    return {};
+  } // get_handle
+
+}; // struct storage_type_t
+
+} // namespace hpx
+} // namespace data
+} // namespace flecsi
+
+#endif // flecsi_hpx_tuple_h
+
+/*~-------------------------------------------------------------------------~-*
+ * Formatting options
+ * vim: set tabstop=2 shiftwidth=2 expandtab :
+ *~-------------------------------------------------------------------------~-*/

--- a/flecsi/data/test/data_client.cc
+++ b/flecsi/data/test/data_client.cc
@@ -61,7 +61,7 @@ TEST(data_client, destructor) {
 
   // get all accessors to the data
   auto accs = flecsi_get_handles(*dc, hydro, double, global, 0);
-  
+
   ASSERT_EQ( accs.size(), 2 );
   ASSERT_EQ( accs[0].label(), "density" );
   ASSERT_EQ( accs[1].label(), "pressure" );
@@ -85,7 +85,7 @@ TEST(data_client, move) {
   // create new data_clients
   derived_t dc1, dc2;
   auto rid1 = dc1.runtime_id();
-  
+
 // TODO: fix
 #if FLECSI_RUNTIME_MODEL == FLECSI_RUNTIME_MODEL_serial
   // Register data
@@ -96,7 +96,7 @@ TEST(data_client, move) {
   // get all accessors to the data
   {
     auto accs = flecsi_get_handles(dc1, hydro, double, global, 0);
-  
+
     ASSERT_EQ( accs.size(), 2 );
     ASSERT_EQ( accs[0].label(), "density" );
     ASSERT_EQ( accs[1].label(), "pressure" );
@@ -112,7 +112,7 @@ TEST(data_client, move) {
   // it should show up in the new data client though
   {
     auto accs = flecsi_get_handles(dc2, hydro, double, global, 0);
-  
+
     ASSERT_EQ( accs.size(), 2 );
     ASSERT_EQ( accs[0].label(), "density" );
     ASSERT_EQ( accs[1].label(), "pressure" );

--- a/flecsi/execution/CMakeLists.txt
+++ b/flecsi/execution/CMakeLists.txt
@@ -6,8 +6,8 @@
 # /@@////   /@@/@@@@@@@/@@       ////////@@/@@
 # /@@       /@@/@@//// //@@    @@       /@@/@@
 # /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
-# //       ///  //////   //////  ////////  // 
-# 
+# //       ///  //////   //////  ////////  //
+#
 # Copyright (c) 2016 Los Alamos National Laboratory, LLC
 # All rights reserved
 #------------------------------------------------------------------------------#
@@ -93,6 +93,21 @@ elseif(FLECSI_RUNTIME_MODEL STREQUAL "mpi")
 
   set(UNIT_POLICY MPI)
   set(RUNTIME_DRIVER mpi/runtime_driver.cc)
+
+elseif(FLECSI_RUNTIME_MODEL STREQUAL "hpx")
+
+  set(execution_HEADERS
+    ${execution_HEADERS}
+    hpx/context_policy.h
+    hpx/execution_policy.h
+    hpx/runtime_driver.h
+  )
+  set(execution_SOURCES
+    ${execution_SOURCES}
+    hpx/context_policy.cc
+    )
+  set(UNIT_POLICY HPX)
+  set(RUNTIME_DRIVER hpx/runtime_driver.cc)
 
 endif()
 

--- a/flecsi/execution/hpx/context_policy.cc
+++ b/flecsi/execution/hpx/context_policy.cc
@@ -60,10 +60,8 @@ hpx_context_policy_t::start_hpx(
       // disable HPX' short options
       "hpx.commandline.aliasing!=0"};
 
-  using hpx::util::placeholders::_1;
-  using hpx::util::placeholders::_2;
   hpx::util::function_nonser<int(int, char **)> start_function =
-      hpx::util::bind(&hpx_context_policy_t::hpx_main, this, driver, _1, _2);
+      hpx::util::bind_front(&hpx_context_policy_t::hpx_main, this, driver);
 
   return hpx::init(start_function, argc, argv, cfg);
 }

--- a/flecsi/execution/hpx/context_policy.cc
+++ b/flecsi/execution/hpx/context_policy.cc
@@ -1,0 +1,77 @@
+/*~-------------------------------------------------------------------------~~*
+ * Copyright (c) 2014 Los Alamos National Security, LLC
+ * All rights reserved.
+ *~-------------------------------------------------------------------------~~*/
+
+//----------------------------------------------------------------------------//
+//! @file
+//! @date Initial file creation: Jul 26, 2016
+//----------------------------------------------------------------------------//
+
+#if !defined(ENABLE_HPX)
+#error ENABLE_HPX not defined! This file depends on HPX!
+#endif
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <flecsi/execution/hpx/context_policy.h>
+
+#include <flecsi/data/storage.h>
+
+namespace flecsi {
+namespace execution {
+
+hpx_context_policy_t::hpx_context_policy_t() {
+#if defined(_MSC_VER)
+  hpx::detail::init_winsocket();
+#endif
+}
+
+// Main HPX thread, does nothing but wait for the application to exit
+int
+hpx_context_policy_t::hpx_main(
+    int (*driver)(int, char * []),
+    int argc,
+    char * argv[]) {
+  // execute user code (driver)
+  int retval = (*driver)(argc, argv);
+
+  // tell the runtime it's ok to exit
+  hpx::finalize();
+
+  return retval;
+}
+
+int
+hpx_context_policy_t::start_hpx(
+    int (*driver)(int, char * []),
+    int argc,
+    char * argv[]) {
+  std::vector<std::string> const cfg = {
+      // make sure hpx_main is always executed
+      "hpx.run_hpx_main!=1",
+      // allow for unknown command line options
+      "hpx.commandline.allow_unknown!=1",
+      // disable HPX' short options
+      "hpx.commandline.aliasing!=0"};
+
+  using hpx::util::placeholders::_1;
+  using hpx::util::placeholders::_2;
+  hpx::util::function_nonser<int(int, char **)> start_function =
+      hpx::util::bind(&hpx_context_policy_t::hpx_main, this, driver, _1, _2);
+
+  return hpx::init(start_function, argc, argv, cfg);
+}
+
+} // namespace execution
+} // namespace flecsi
+
+/*~------------------------------------------------------------------------~--*
+ * Formatting options for vim.
+ * vim: set tabstop=2 shiftwidth=2 expandtab :
+ *~------------------------------------------------------------------------~--*/

--- a/flecsi/execution/hpx/context_policy.h
+++ b/flecsi/execution/hpx/context_policy.h
@@ -65,46 +65,6 @@ struct hpx_context_policy_t {
     return start_hpx(&hpx_runtime_driver, argc, argv);
   } // hpx_context_policy_t::initialize
 
-  //------------------------------------------------------------------------//
-  // Function registration.
-  //------------------------------------------------------------------------//
-
-  ///
-  /// \tparam T The type of the function being registered.
-  ///
-  /// \param key A unique function identifier.
-  ///
-  /// \return A boolean value that is true if the registration succeeded,
-  ///         false otherwise.
-  ///
-  template<
-      typename RETURN,
-      typename ARG_TUPLE,
-      RETURN (*FUNCTION)(ARG_TUPLE),
-      size_t KEY>
-  bool register_function() {
-    clog_assert(
-        function_registry_.find(KEY) == function_registry_.end(),
-        "function has already been registered");
-
-    clog(info) << "Registering function: " << FUNCTION << std::endl;
-
-    function_registry_[KEY] = reinterpret_cast<void *>(FUNCTION);
-    return true;
-  } // register_function
-
-  ///
-  /// Return the function associated with \e key.
-  ///
-  /// \param key The unique function identifier.
-  ///
-  /// \return A pointer to a std::function<void(void)> that may be cast
-  ///         back to the original function type using reinterpret_cast.
-  ///
-  void * function(size_t key) {
-    return function_registry_[key];
-  } // function
-
 protected:
   // Helper function for HPX start-up and shutdown
   FLECSI_EXPORT int
@@ -113,21 +73,6 @@ protected:
   // Start the HPX runtime system,
   FLECSI_EXPORT int
   start_hpx(int (*driver)(int, char * []), int argc, char * argv[]);
-
-private:
-  //--------------------------------------------------------------------------//
-  // Task data members.
-  //--------------------------------------------------------------------------//
-
-  // Map to store task registration callback methods.
-  //  std::map<
-  //    size_t,
-  //    task_info_t
-  //  > task_registry_;
-
-  // Function registry
-  std::unordered_map<size_t, void *> function_registry_;
-
 }; // struct hpx_context_policy_t
 
 } // namespace execution

--- a/flecsi/execution/hpx/context_policy.h
+++ b/flecsi/execution/hpx/context_policy.h
@@ -1,0 +1,141 @@
+/*~--------------------------------------------------------------------------~*
+ *  @@@@@@@@  @@           @@@@@@   @@@@@@@@ @@
+ * /@@/////  /@@          @@////@@ @@////// /@@
+ * /@@       /@@  @@@@@  @@    // /@@       /@@
+ * /@@@@@@@  /@@ @@///@@/@@       /@@@@@@@@@/@@
+ * /@@////   /@@/@@@@@@@/@@       ////////@@/@@
+ * /@@       /@@/@@//// //@@    @@       /@@/@@
+ * /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
+ * //       ///  //////   //////  ////////  //
+ *
+ * Copyright (c) 2016 Los Alamos National Laboratory, LLC
+ * All rights reserved
+ *~--------------------------------------------------------------------------~*/
+
+#ifndef flecsi_execution_hpx_context_policy_h
+#define flecsi_execution_hpx_context_policy_h
+
+#if !defined(ENABLE_HPX)
+#error ENABLE_HPX not defined! This file depends on HPX!
+#endif
+
+#include <hpx/lcos/local/condition_variable.hpp>
+#include <hpx/lcos/local/spinlock.hpp>
+#include <hpx/runtime_fwd.hpp>
+
+#include <functional>
+#include <map>
+#include <mutex>
+
+#include "flecsi/execution/common/launch.h"
+#include "flecsi/execution/common/processor.h"
+#include "flecsi/execution/hpx/runtime_driver.h"
+#include "flecsi/utils/common.h"
+#include "flecsi/utils/const_string.h"
+#include "flecsi/utils/export_definitions.h"
+
+///
+/// \file hpx/execution_policy.h
+/// \authors bergen
+/// \date Initial file creation: Nov 15, 2015
+///
+
+namespace flecsi {
+namespace execution {
+
+///////////////////////////////////////////////////////////////////////////////
+struct hpx_context_policy_t {
+  //------------------------------------------------------------------------//
+  // Initialization.
+  //------------------------------------------------------------------------//
+
+  FLECSI_EXPORT hpx_context_policy_t();
+
+  ///
+  /// Initialize the context runtime. The arguments to this method should
+  /// be passed from the main function.
+  ///
+  /// \param argc The number of command-line arguments.
+  /// \param argv The array of command-line arguments.
+  ///
+  /// \return Zero upon clean initialization, non-zero otherwise.
+  ///
+  int initialize(int argc, char * argv[]) {
+    // start HPX runtime system, execute driver code in the context of HPX
+    return start_hpx(&hpx_runtime_driver, argc, argv);
+  } // hpx_context_policy_t::initialize
+
+  //------------------------------------------------------------------------//
+  // Function registration.
+  //------------------------------------------------------------------------//
+
+  ///
+  /// \tparam T The type of the function being registered.
+  ///
+  /// \param key A unique function identifier.
+  ///
+  /// \return A boolean value that is true if the registration succeeded,
+  ///         false otherwise.
+  ///
+  template<
+      typename RETURN,
+      typename ARG_TUPLE,
+      RETURN (*FUNCTION)(ARG_TUPLE),
+      size_t KEY>
+  bool register_function() {
+    clog_assert(
+        function_registry_.find(KEY) == function_registry_.end(),
+        "function has already been registered");
+
+    clog(info) << "Registering function: " << FUNCTION << std::endl;
+
+    function_registry_[KEY] = reinterpret_cast<void *>(FUNCTION);
+    return true;
+  } // register_function
+
+  ///
+  /// Return the function associated with \e key.
+  ///
+  /// \param key The unique function identifier.
+  ///
+  /// \return A pointer to a std::function<void(void)> that may be cast
+  ///         back to the original function type using reinterpret_cast.
+  ///
+  void * function(size_t key) {
+    return function_registry_[key];
+  } // function
+
+protected:
+  // Helper function for HPX start-up and shutdown
+  FLECSI_EXPORT int
+  hpx_main(int (*driver)(int, char * []), int argc, char * argv[]);
+
+  // Start the HPX runtime system,
+  FLECSI_EXPORT int
+  start_hpx(int (*driver)(int, char * []), int argc, char * argv[]);
+
+private:
+  //--------------------------------------------------------------------------//
+  // Task data members.
+  //--------------------------------------------------------------------------//
+
+  // Map to store task registration callback methods.
+  //  std::map<
+  //    size_t,
+  //    task_info_t
+  //  > task_registry_;
+
+  // Function registry
+  std::unordered_map<size_t, void *> function_registry_;
+
+}; // struct hpx_context_policy_t
+
+} // namespace execution
+} // namespace flecsi
+
+#endif // flecsi_execution_hpx_context_policy_h
+
+/*~-------------------------------------------------------------------------~-*
+ * Formatting options
+ * vim: set tabstop=2 shiftwidth=2 expandtab :
+ *~-------------------------------------------------------------------------~-*/

--- a/flecsi/execution/hpx/execution_policy.h
+++ b/flecsi/execution/hpx/execution_policy.h
@@ -1,0 +1,204 @@
+/*~--------------------------------------------------------------------------~*
+ *  @@@@@@@@  @@           @@@@@@   @@@@@@@@ @@
+ * /@@/////  /@@          @@////@@ @@////// /@@
+ * /@@       /@@  @@@@@  @@    // /@@       /@@
+ * /@@@@@@@  /@@ @@///@@/@@       /@@@@@@@@@/@@
+ * /@@////   /@@/@@@@@@@/@@       ////////@@/@@
+ * /@@       /@@/@@//// //@@    @@       /@@/@@
+ * /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
+ * //       ///  //////   //////  ////////  //
+ *
+ * Copyright (c) 2016 Los Alamos National Laboratory, LLC
+ * All rights reserved
+ *~--------------------------------------------------------------------------~*/
+
+#ifndef flecsi_execution_hpx_execution_policy_h
+#define flecsi_execution_hpx_execution_policy_h
+
+#include <hpx/include/async.hpp>
+#include <hpx/include/lcos.hpp>
+
+#include <functional>
+#include <tuple>
+#include <unordered_map>
+
+#include <flecsi/execution/common/launch.h>
+#include <flecsi/execution/common/processor.h>
+#include <flecsi/execution/context.h>
+#include <flecsi/execution/hpx/runtime_driver.h>
+#include <flecsi/execution/hpx/task_wrapper.h>
+#include <flecsi/utils/const_string.h>
+#include <flecsi/utils/export_definitions.h>
+#include <flecsi/utils/tuple_function.h>
+//#include "flecsi/execution/task.h"
+
+///
+// \file hpx/execution_policy.h
+// \authors bergen
+// \date Initial file creation: Nov 15, 2015
+///
+
+namespace flecsi {
+namespace execution {
+
+//----------------------------------------------------------------------------//
+// Future.
+//----------------------------------------------------------------------------//
+
+///
+/// Executor interface.
+///
+template<typename RETURN, typename ARG_TUPLE>
+struct executor__ {
+  ///
+  ///
+  ///
+  template<typename T, typename A>
+  static decltype(auto) execute(T fun, A && targs) {
+    auto user_fun = (reinterpret_cast<RETURN (*)(ARG_TUPLE)>(fun));
+    return hpx::async(std::move(user_fun), std::forward<A>(targs));
+  } // execute_task
+}; // struct executor__
+
+// template<
+//   typename RETURN,
+//   typename ARG_TUPLE>
+// struct mpi_executor__
+// {
+//   ///
+//   ///
+//   ///
+//   template<
+//     typename T,
+//     typename A
+//   >
+//   static
+//   decltype(auto)
+//   execute(
+//     T fun,
+//     A && targs
+//   )
+//   {
+//     auto user_fun = (reinterpret_cast<RETURN(*)(ARG_TUPLE)>(fun));
+//     return hpx::async(std::move(user_fun), std::forward<A>(targs));
+//   } // execute_task
+// }; // struct mpi_executor__
+
+//----------------------------------------------------------------------------//
+// Execution policy.
+//----------------------------------------------------------------------------//
+
+///
+/// \struct hpx_execution_policy hpx_execution_policy.h
+/// \brief hpx_execution_policy provides...
+///
+struct FLECSI_EXPORT hpx_execution_policy_t {
+  template<typename R>
+  using future__ = hpx::future<R>;
+
+  //--------------------------------------------------------------------------//
+  //! The task_wrapper__ type FIXME
+  //!
+  //! @tparam RETURN The return type of the task. FIXME
+  //--------------------------------------------------------------------------//
+
+  template<typename FUNCTOR_TYPE>
+  using functor_task_wrapper__ =
+      typename flecsi::execution::functor_task_wrapper__<FUNCTOR_TYPE>;
+
+  struct runtime_state_t {};
+
+  //   static
+  //   runtime_state_t &
+  //   runtime_state(
+  //     void * task
+  //   )
+  //   {
+  //     return {};
+  //   }
+  //--------------------------------------------------------------------------//
+  // Task interface.
+  //--------------------------------------------------------------------------//
+
+  ///
+  /// hpx task registration.
+  ///
+  /// \tparam R The return type of the task.
+  /// \tparam A The arguments type of the task. This is a std::tuple of the
+  ///           user task arguments.
+  ///
+  template<
+      size_t KEY,
+      typename RETURN,
+      typename ARG_TUPLE,
+      RETURN (*DELEGATE)(ARG_TUPLE)>
+  static bool
+  register_task(processor_type_t processor, launch_t launch, std::string name) {
+    return context_t::instance()
+        .template register_function<RETURN, ARG_TUPLE, DELEGATE, KEY>();
+  } // register_task
+
+  ///
+  /// \tparam R The task return type.
+  /// \tparam T The user task type.
+  /// \tparam As The user task argument types.
+  ///
+  /// \param key
+  /// \param user_task_handle
+  /// \param args
+  ///
+  template<size_t KEY, typename RETURN, typename ARG_TUPLE, typename... ARGS>
+  static decltype(auto) execute_task(launch_type_t launch, ARGS &&... args) {
+    context_t & context_ = context_t::instance();
+
+    // Get the function and processor type.
+    auto fun = context_.function(KEY);
+
+    //     auto processor_type = context_.processor_type<KEY>();
+    //     if (launch == processor_type_t::mpi)
+
+    return executor__<RETURN, ARG_TUPLE>::execute(
+        fun, std::forward_as_tuple(args...));
+  } // execute_task
+
+  //--------------------------------------------------------------------------//
+  // Function interface.
+  //--------------------------------------------------------------------------//
+  template<
+      typename RETURN,
+      typename ARG_TUPLE,
+      RETURN (*FUNCTION)(ARG_TUPLE),
+      size_t KEY>
+  static bool register_function() {
+    return context_t::instance()
+        .template register_function<RETURN, ARG_TUPLE, FUNCTION, KEY>();
+  } // register_function
+
+  ///
+  /// This method looks up a function from the \e handle argument
+  /// and executes the associated it with the provided \e args arguments.
+  ///
+  /// \param handle The function handle to execute.
+  /// \param args A variadic argument list of the function parameters.
+  ///
+  /// \return The return type of the provided function handle.
+  ///
+  template<typename FUNCTION_HANDLE, typename... ARGS>
+  static decltype(auto)
+  execute_function(FUNCTION_HANDLE & handle, ARGS &&... args) {
+    return handle(
+        context_t::instance().function(handle.key()),
+        std::forward_as_tuple(args...));
+  } // execute_function
+
+}; // struct hpx_execution_policy_t
+
+} // namespace execution
+} // namespace flecsi
+
+#endif // flecsi_execution_hpx_execution_policy_h
+
+/*~-------------------------------------------------------------------------~-*
+ * Formatting options
+ * vim: set tabstop=2 shiftwidth=2 expandtab :
+ *~-------------------------------------------------------------------------~-*/

--- a/flecsi/execution/hpx/execution_policy.h
+++ b/flecsi/execution/hpx/execution_policy.h
@@ -128,14 +128,21 @@ struct FLECSI_EXPORT hpx_execution_policy_t {
   ///           user task arguments.
   ///
   template<
-      size_t KEY,
-      typename RETURN,
-      typename ARG_TUPLE,
-      RETURN (*DELEGATE)(ARG_TUPLE)>
-  static bool
-  register_task(processor_type_t processor, launch_t launch, std::string name) {
-    return context_t::instance()
-        .template register_function<RETURN, ARG_TUPLE, DELEGATE, KEY>();
+    size_t KEY,
+    typename RETURN,
+    typename ARG_TUPLE,
+    RETURN (*DELEGATE)(ARG_TUPLE)
+  >
+  static
+  bool
+  register_task(
+     processor_type_t processor,
+     launch_t launch,
+     std::string name
+  )
+  {
+    return context_t::instance().template register_function<
+      KEY, RETURN, ARG_TUPLE, DELEGATE>();
   } // register_task
 
   ///
@@ -165,13 +172,16 @@ struct FLECSI_EXPORT hpx_execution_policy_t {
   // Function interface.
   //--------------------------------------------------------------------------//
   template<
-      typename RETURN,
-      typename ARG_TUPLE,
-      RETURN (*FUNCTION)(ARG_TUPLE),
-      size_t KEY>
-  static bool register_function() {
-    return context_t::instance()
-        .template register_function<RETURN, ARG_TUPLE, FUNCTION, KEY>();
+    size_t KEY,
+    typename RETURN,
+    typename ARG_TUPLE,
+    RETURN (*FUNCTION)(ARG_TUPLE)>
+  static
+  bool
+  register_function()
+  {
+    return context_t::instance().template register_function<
+      KEY, RETURN, ARG_TUPLE, FUNCTION>();
   } // register_function
 
   ///

--- a/flecsi/execution/hpx/internal_task.h
+++ b/flecsi/execution/hpx/internal_task.h
@@ -1,0 +1,64 @@
+/*~--------------------------------------------------------------------------~*
+ * Copyright (c) 2015 Los Alamos National Security, LLC
+ * All rights reserved.
+ *~--------------------------------------------------------------------------~*/
+
+#pragma once
+
+//----------------------------------------------------------------------------//
+//! @file
+//! @date Initial file creation: Mar 31, 2017
+//----------------------------------------------------------------------------//
+
+#include <hpx/hpx.hpp>
+
+#include <flecsi/execution/common/processor.h>
+#include <flecsi/execution/context.h>
+#include <flecsi/execution/execution.h>
+#include <flecsi/utils/common.h>
+
+//----------------------------------------------------------------------------//
+//! @def __flecsi_internal_task_key
+//!
+//! Convenience macro to create a task key from hpx task information.
+//!
+//! @param task      The hpx task to register.
+//! @param processor The processor type \ref processor_t.
+//! @param single    A boolean indicating whether this task can be run as a
+//!                  single task.
+//! @param index     A boolean indicating whether this task can be run as an
+//!                  index space launch.
+//!
+//! @ingroup hpx-execution
+//----------------------------------------------------------------------------//
+
+#define __flecsi_internal_task_key(task)                                       \
+/* MACRO IMPLEMENTATION */                                                     \
+                                                                               \
+  /* Use const_string_t interface to create the key */                         \
+  flecsi::utils::const_string_t{EXPAND_AND_STRINGIFY(task)}.hash()
+
+//----------------------------------------------------------------------------//
+//! @def __flecsi_internal_register_hpx_task
+//!
+//! This macro registers an internal hpx task.
+//!
+//! @param task      The hpx task to register.
+//! @param processor A processor_mask_t specifying the supported processor
+//!                  types.
+//! @param launch    A launch_t specifying the launch options.
+//!
+//! @ingroup hpx-execution
+//----------------------------------------------------------------------------//
+
+#define __flecsi_internal_register_hpx_task(task, processor, launch)        \
+/* MACRO IMPLEMENTATION */                                                     \
+                                                                               \
+  /* Call the execution policy to register the task */                         \
+  bool task ## _task_registered =                                              \
+    flecsi::execution::hpx_execution_policy_t::register_hpx_task<        \
+      flecsi::utils::const_string_t{EXPAND_AND_STRINGIFY(task)}.hash(),        \
+      typename flecsi::utils::function_traits__<decltype(task)>::return_type,  \
+      task                                                                     \
+    >                                                                          \
+    (processor, launch, { EXPAND_AND_STRINGIFY(task) })

--- a/flecsi/execution/hpx/processor_policy.h
+++ b/flecsi/execution/hpx/processor_policy.h
@@ -1,0 +1,32 @@
+/*~--------------------------------------------------------------------------~*
+ * Copyright (c) 2015 Los Alamos National Security, LLC
+ * All rights reserved.
+ *~--------------------------------------------------------------------------~*/
+
+#ifndef flecsi_execution_hpx_processor_policy_h
+#define flecsi_execution_hpx_processor_policy_h
+
+///
+/// \file
+/// \date Initial file creation: Apr 12, 2017
+///
+
+
+namespace flecsi {
+namespace execution {
+
+enum class serial_processor_type_t : size_t {
+  loc,
+  toc,
+  mpi
+};
+
+} // namespace execution
+} // namespace flecsi
+
+#endif // flecsi_execution_hpx_processor_policy_h
+
+/*~-------------------------------------------------------------------------~-*
+ * Formatting options for vim.
+ * vim: set tabstop=2 shiftwidth=2 expandtab :
+ *~-------------------------------------------------------------------------~-*/

--- a/flecsi/execution/hpx/runtime_driver.cc
+++ b/flecsi/execution/hpx/runtime_driver.cc
@@ -1,0 +1,39 @@
+/*~-------------------------------------------------------------------------~~*
+ * Copyright (c) 2014 Los Alamos National Security, LLC
+ * All rights reserved.
+ *~-------------------------------------------------------------------------~~*/
+
+//----------------------------------------------------------------------------//
+//! @file
+//! @date Initial file creation: Aug 01, 2016
+//----------------------------------------------------------------------------//
+
+#include <flecsi/execution/hpx/runtime_driver.h>
+
+namespace flecsi {
+namespace execution {
+
+//----------------------------------------------------------------------------//
+// Implementation of FleCSI runtime driver task.
+//----------------------------------------------------------------------------//
+
+int hpx_runtime_driver(int argc, char ** argv) {
+
+#if defined FLECSI_ENABLE_SPECIALIZATION_TLT_INIT
+  // Execute the specialization driver.
+  specialization_tlt_init(argc, argv);
+#endif // FLECSI_ENABLE_SPECIALIZATION_TLT_INIT
+
+  // Execute the user driver.
+  driver(argc, argv);
+
+  return 0;
+} // hpx_runtime_driver
+
+} // namespace execution
+} // namespace flecsi
+
+/*~------------------------------------------------------------------------~--*
+ * Formatting options for vim.
+ * vim: set tabstop=2 shiftwidth=2 expandtab :
+ *~------------------------------------------------------------------------~--*/

--- a/flecsi/execution/hpx/runtime_driver.h
+++ b/flecsi/execution/hpx/runtime_driver.h
@@ -1,0 +1,40 @@
+/*~--------------------------------------------------------------------------~*
+ * Copyright (c) 2015 Los Alamos National Security, LLC
+ * All rights reserved.
+ *~--------------------------------------------------------------------------~*/
+
+#ifndef flecsi_execution_hpx_runtime_driver_h
+#define flecsi_execution_hpx_runtime_driver_h
+
+///
+/// \file
+/// \date Initial file creation: Aug 01, 2016
+///
+
+namespace flecsi {
+namespace execution {
+
+//! \brief The main driver function to be defined by the user.
+//! \param[in] argc  The number of arguments in argv.
+//! \param[in] argv  The list arguments passed to the driver.
+void driver(int argc, char ** argv);
+
+//! \brief The specialization driver function to be defined by the user.
+//! \param[in] argc  The number of arguments in argv.
+//! \param[in] argv  The list arguments passed to the driver.
+void specialization_tlt_init(int argc, char ** argv);
+
+//! \brief The top-level serial runtime driver.
+//! \param[in] argc  The number of arguments in argv.
+//! \param[in] argv  The list arguments passed to the driver.
+int hpx_runtime_driver(int argc, char ** argv);
+
+} // namespace execution
+} // namespace flecsi
+
+#endif // flecsi_execution_hpx_runtime_driver_h
+
+/*~-------------------------------------------------------------------------~-*
+ * Formatting options for vim.
+ * vim: set tabstop=2 shiftwidth=2 expandtab :
+ *~-------------------------------------------------------------------------~-*/

--- a/flecsi/execution/hpx/task_wrapper.h
+++ b/flecsi/execution/hpx/task_wrapper.h
@@ -1,0 +1,44 @@
+/*~--------------------------------------------------------------------------~*
+ * Copyright (c) 2015 Los Alamos National Security, LLC
+ * All rights reserved.
+ *~--------------------------------------------------------------------------~*/
+
+#ifndef flecsi_execution_hpx_task_wrapper_h
+#define flecsi_execution_hpx_task_wrapper_h
+
+clog_register_tag(wrapper);
+
+namespace flecsi {
+namespace execution
+{
+
+template <
+  typename FUNCTOR_TYPE
+>
+struct functor_task_wrapper__
+{
+};
+
+template <
+  size_t KEY,
+  typename RETURN,
+  typename ARG_TUPLE,
+  RETURN (* DELEGATE)(ARG_TUPLE)
+>
+struct task_wrapper__
+{
+  //--------------------------------------------------------------------------//
+  //! The task_args_t type defines a task argument type for task
+  //! execution through the HPX runtime.
+  //--------------------------------------------------------------------------//
+
+//  using task_args_t =
+//    typename utils::base_convert_tuple_type<
+//    accessor_base_t, data_handle__<void, 0, 0, 0>, ARG_TUPLE>::type;
+
+
+};
+
+}
+}
+#endif //flecsi_execution_hpx_task_wrapper_h

--- a/flecsi/geometry/CMakeLists.txt
+++ b/flecsi/geometry/CMakeLists.txt
@@ -6,8 +6,8 @@
 # /@@////   /@@/@@@@@@@/@@       ////////@@/@@
 # /@@       /@@/@@//// //@@    @@       /@@/@@
 # /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
-# //       ///  //////   //////  ////////  // 
-# 
+# //       ///  //////   //////  ////////  //
+#
 # Copyright (c) 2016 Los Alamos National Laboratory, LLC
 # All rights reserved
 #------------------------------------------------------------------------------#
@@ -43,6 +43,11 @@ elseif(FLECSI_RUNTIME_MODEL STREQUAL "mpi")
 
   set(UNIT_POLICY LEGION)
   set(RUNTIME_DRIVER mpi/runtime_driver.cc)
+
+elseif(FLECSI_RUNTIME_MODEL STREQUAL "hpx")
+
+  set(UNIT_POLICY HPX)
+  set(RUNTIME_DRIVER hpx/runtime_driver.cc)
 
 endif()
 

--- a/flecsi/io/CMakeLists.txt
+++ b/flecsi/io/CMakeLists.txt
@@ -6,8 +6,8 @@
 # /@@////   /@@/@@@@@@@/@@       ////////@@/@@
 # /@@       /@@/@@//// //@@    @@       /@@/@@
 # /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
-# //       ///  //////   //////  ////////  // 
-# 
+# //       ///  //////   //////  ////////  //
+#
 # Copyright (c) 2016 Los Alamos National Laboratory, LLC
 # All rights reserved
 #------------------------------------------------------------------------------#
@@ -44,6 +44,11 @@ elseif(FLECSI_RUNTIME_MODEL STREQUAL "mpi")
 
   set(UNIT_POLICY LEGION)
   set(RUNTIME_DRIVER mpi/runtime_driver.cc)
+
+elseif(FLECSI_RUNTIME_MODEL STREQUAL "hpx")
+
+  set(UNIT_POLICY HPX)
+  set(RUNTIME_DRIVER hpx/runtime_driver.cc)
 
 endif()
 

--- a/flecsi/runtime/flecsi_runtime_context_policy.h
+++ b/flecsi/runtime/flecsi_runtime_context_policy.h
@@ -50,4 +50,17 @@ using FLECSI_RUNTIME_CONTEXT_POLICY = mpi_context_policy_t;
 } // namespace execution
 } // namespace flecsi
 
+// HPX Policy
+#elif FLECSI_RUNTIME_MODEL == FLECSI_RUNTIME_MODEL_hpx
+
+#include <flecsi/execution/hpx/context_policy.h>
+
+namespace flecsi {
+namespace execution {
+
+using FLECSI_RUNTIME_CONTEXT_POLICY = hpx_context_policy_t;
+
+} // namespace execution
+} // namespace flecsi
+
 #endif // FLECSI_RUNTIME_MODEL

--- a/flecsi/runtime/flecsi_runtime_data_client_handle_policy.h
+++ b/flecsi/runtime/flecsi_runtime_data_client_handle_policy.h
@@ -48,4 +48,16 @@ using FLECSI_RUNTIME_DATA_CLIENT_HANDLE_POLICY =
 
 } // namespace flecsi
 
+// HPX Policy
+#elif FLECSI_RUNTIME_MODEL == FLECSI_RUNTIME_MODEL_hpx
+
+#include <flecsi/data/hpx/data_client_handle_policy.h>
+
+namespace flecsi {
+
+using FLECSI_RUNTIME_DATA_CLIENT_HANDLE_POLICY =
+    hpx_data_client_handle_policy_t;
+
+} // namespace flecsi
+
 #endif // FLECSI_RUNTIME_MODEL

--- a/flecsi/runtime/flecsi_runtime_data_handle_policy.h
+++ b/flecsi/runtime/flecsi_runtime_data_handle_policy.h
@@ -35,10 +35,10 @@
 namespace flecsi {
 
 using FLECSI_RUNTIME_DENSE_DATA_HANDLE_POLICY =
-		legion_dense_data_handle_policy_t;
+    legion_dense_data_handle_policy_t;
 
 using FLECSI_RUNTIME_GLOBAL_DATA_HANDLE_POLICY =
-                legion_global_data_handle_policy_t;
+    legion_global_data_handle_policy_t;
 
 using FLECSI_RUNTIME_SPARSE_DATA_HANDLE_POLICY =
     legion_sparse_data_handle_policy_t;
@@ -58,13 +58,24 @@ namespace flecsi {
 
 using FLECSI_RUNTIME_DENSE_DATA_HANDLE_POLICY = mpi_data_handle_policy_t;
 
-using FLECSI_RUNTIME_GLOBAL_DATA_HANDLE_POLICY =
-	mpi_data_handle_policy_t;
-
-using FLECSI_RUNTIME_SPARSE_DATA_HANDLE_POLICY =
-    mpi_sparse_data_handle_policy_t;
+using FLECSI_RUNTIME_GLOBAL_DATA_HANDLE_POLICY = mpi_data_handle_policy_t;
 
 using FLECSI_RUNTIME_MUTATOR_HANDLE_POLICY = mpi_mutator_handle_policy_t;
+
+} // namespace flecsi
+
+// HPX Policy
+#elif FLECSI_RUNTIME_MODEL == FLECSI_RUNTIME_MODEL_hpx
+
+#include <flecsi/data/hpx/data_handle_policy.h>
+
+namespace flecsi {
+
+using FLECSI_RUNTIME_DENSE_DATA_HANDLE_POLICY = hpx_data_handle_policy_t;
+
+using FLECSI_RUNTIME_GLOBAL_DATA_HANDLE_POLICY = hpx_data_handle_policy_t;
+
+using FLECSI_RUNTIME_MUTATOR_HANDLE_POLICY = hpx_data_handle_policy_t;
 
 } // namespace flecsi
 

--- a/flecsi/runtime/flecsi_runtime_data_handle_policy.h
+++ b/flecsi/runtime/flecsi_runtime_data_handle_policy.h
@@ -60,6 +60,9 @@ using FLECSI_RUNTIME_DENSE_DATA_HANDLE_POLICY = mpi_data_handle_policy_t;
 
 using FLECSI_RUNTIME_GLOBAL_DATA_HANDLE_POLICY = mpi_data_handle_policy_t;
 
+using FLECSI_RUNTIME_SPARSE_DATA_HANDLE_POLICY =
+    mpi_sparse_data_handle_policy_t;
+
 using FLECSI_RUNTIME_MUTATOR_HANDLE_POLICY = mpi_mutator_handle_policy_t;
 
 } // namespace flecsi

--- a/flecsi/runtime/flecsi_runtime_data_policy.h
+++ b/flecsi/runtime/flecsi_runtime_data_policy.h
@@ -50,4 +50,17 @@ using FLECSI_RUNTIME_DATA_POLICY = mpi_data_policy_t;
 } // namespace data
 } // namespace flecsi
 
+// HPX Policy
+#elif FLECSI_RUNTIME_MODEL == FLECSI_RUNTIME_MODEL_hpx
+
+#include <flecsi/data/hpx/data_policy.h>
+
+namespace flecsi {
+namespace data {
+
+using FLECSI_RUNTIME_DATA_POLICY = hpx_data_policy_t;
+
+} // namespace data
+} // namespace flecsi
+
 #endif // FLECSI_RUNTIME_MODEL

--- a/flecsi/runtime/flecsi_runtime_entity_storage_policy.h
+++ b/flecsi/runtime/flecsi_runtime_entity_storage_policy.h
@@ -52,4 +52,18 @@ using FLECSI_RUNTIME_OFFSET_STORAGE_TYPE = topology::offset_storage_;
 
 } // namespace flecsi
 
+// HPX Policy
+#elif FLECSI_RUNTIME_MODEL == FLECSI_RUNTIME_MODEL_hpx
+
+#include <flecsi/topology/common/entity_storage.h>
+
+namespace flecsi {
+
+template<typename T>
+using FLECSI_RUNTIME_ENTITY_STORAGE_TYPE = topology::topology_storage__<T>;
+
+using FLECSI_RUNTIME_OFFSET_STORAGE_TYPE = topology::offset_storage_;
+
+} // namespace flecsi
+
 #endif // FLECSI_RUNTIME_MODEL

--- a/flecsi/runtime/flecsi_runtime_execution_policy.h
+++ b/flecsi/runtime/flecsi_runtime_execution_policy.h
@@ -50,4 +50,17 @@ using FLECSI_RUNTIME_EXECUTION_POLICY = mpi_execution_policy_t;
 } // namespace execution
 } // namespace flecsi
 
+// HPX Policy
+#elif FLECSI_RUNTIME_MODEL == FLECSI_RUNTIME_MODEL_hpx
+
+#include <flecsi/execution/hpx/execution_policy.h>
+
+namespace flecsi {
+namespace execution {
+
+using FLECSI_RUNTIME_EXECUTION_POLICY = hpx_execution_policy_t;
+
+} // namespace execution
+} // namespace flecsi
+
 #endif // FLECSI_RUNTIME_MODEL

--- a/flecsi/runtime/flecsi_runtime_storage_policy.h
+++ b/flecsi/runtime/flecsi_runtime_storage_policy.h
@@ -50,4 +50,16 @@ using FLECSI_RUNTIME_STORAGE_POLICY = mpi_storage_policy_t;
 } // namespace data
 } // namespace flecsi
 
+#elif FLECSI_RUNTIME_MODEL == FLECSI_RUNTIME_MODEL_hpx
+
+#include <flecsi/data/hpx/storage_policy.h>
+
+namespace flecsi {
+namespace data {
+
+using FLECSI_RUNTIME_STORAGE_POLICY = hpx_storage_policy_t;
+
+} // namespace data
+} // namespace flecsi
+
 #endif // FLECSI_RUNTIME_MODEL

--- a/flecsi/runtime/flecsi_runtime_topology_policy.h
+++ b/flecsi/runtime/flecsi_runtime_topology_policy.h
@@ -52,4 +52,17 @@ using FLECSI_RUNTIME_TOPOLOGY_STORAGE_POLICY =
 
 } // namespace flecsi
 
+// HPX Policy
+#elif FLECSI_RUNTIME_MODEL == FLECSI_RUNTIME_MODEL_hpx
+
+#include "flecsi/topology/hpx/storage_policy.h"
+
+namespace flecsi {
+
+template<size_t ND, size_t NM>
+using FLECSI_RUNTIME_TOPOLOGY_STORAGE_POLICY =
+    topology::hpx_topology_storage_policy__<ND, NM>;
+
+} // namespace flecsi
+
 #endif // FLECSI_RUNTIME_MODEL

--- a/flecsi/runtime/flecsi_runtime_topology_policy.h
+++ b/flecsi/runtime/flecsi_runtime_topology_policy.h
@@ -59,9 +59,10 @@ using FLECSI_RUNTIME_TOPOLOGY_STORAGE_POLICY =
 
 namespace flecsi {
 
-template<size_t ND, size_t NM>
+template<size_t NUM_DIMS, size_t NUM_DOMAINS, size_t NUM_INDEX_SUBSPACES>
 using FLECSI_RUNTIME_TOPOLOGY_STORAGE_POLICY =
-    topology::hpx_topology_storage_policy__<ND, NM>;
+  topology::hpx_topology_storage_policy__<NUM_DIMS, NUM_DOMAINS,
+  NUM_INDEX_SUBSPACES>;
 
 } // namespace flecsi
 

--- a/flecsi/runtime/types.h
+++ b/flecsi/runtime/types.h
@@ -46,4 +46,13 @@ using task_id_t = size_t;
 
 } // namespace flecsi
 
+#elif FLECSI_RUNTIME_MODEL == FLECSI_RUNTIME_MODEL_hpx
+
+namespace flecsi {
+
+using field_id_t = size_t;
+using task_id_t = size_t;
+
+} // namespace flecsi
+
 #endif // FLECSI_RUNTIME_MODEL

--- a/flecsi/topology/CMakeLists.txt
+++ b/flecsi/topology/CMakeLists.txt
@@ -6,8 +6,8 @@
 # /@@////   /@@/@@@@@@@/@@       ////////@@/@@
 # /@@       /@@/@@//// //@@    @@       /@@/@@
 # /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
-# //       ///  //////   //////  ////////  // 
-# 
+# //       ///  //////   //////  ////////  //
+#
 # Copyright (c) 2016 Los Alamos National Laboratory, LLC
 # All rights reserved
 #------------------------------------------------------------------------------#
@@ -66,6 +66,16 @@ elseif(FLECSI_RUNTIME_MODEL STREQUAL "mpi")
   set(UNIT_POLICY MPI)
   set(RUNTIME_DRIVER ../execution/mpi/runtime_driver.cc)
 
+elseif(FLECSI_RUNTIME_MODEL STREQUAL "hpx")
+
+  set(topology_HEADERS
+    ${topology_HEADERS}
+    hpx/storage_policy.h
+    )
+
+  set(UNIT_POLICY HPX)
+  set(RUNTIME_DRIVER ../execution/hpx/runtime_driver.cc)
+
 endif()
 
 #------------------------------------------------------------------------------#
@@ -100,7 +110,7 @@ if(FLECSI_RUNTIME_MODEL STREQUAL "serial")
    LIBRARIES
      FleCSI
   )
-  
+
   cinch_add_unit(bindings
    SOURCES
      test/bindings.cc

--- a/flecsi/topology/common/entity_storage.h
+++ b/flecsi/topology/common/entity_storage.h
@@ -41,7 +41,7 @@ public:
 
   void add_end(size_t end) {
     assert(end > start_);
-    add_count(end - start_);
+    add_count(static_cast<uint32_t>(end - start_));
   }
 
   std::pair<size_t, size_t> range(size_t i) const {

--- a/flecsi/topology/hpx/storage_policy.h
+++ b/flecsi/topology/hpx/storage_policy.h
@@ -40,7 +40,7 @@ class mesh_entity_t;
 /// \brief hpx_data_handle_policy_t provides...
 ///
 
-template<size_t NUM_DIMS, size_t NUM_DOMS>
+template<size_t NUM_DIMS, size_t NUM_DOMS, size_t NUM_INDEX_SUBSPACES>
 struct hpx_topology_storage_policy__ {
   static constexpr size_t num_partitions = 5;
   using id_t = utils::id_t;
@@ -66,8 +66,8 @@ struct hpx_topology_storage_policy__ {
       NUM_DIMS + 1>;
 
   // array of array of domain_connectivity__
-  std::array<std::array<domain_connectivity__<NUM_DIMS>, NUM_DOMS>, NUM_DOMS>
-      topology;
+  std::array<std::array<domain_connectivity__<NUM_DIMS>, NUM_DOMS>,
+    NUM_DOMS> topology;
 
   std::array<index_spaces_t, NUM_DOMS> index_spaces;
 

--- a/flecsi/topology/hpx/storage_policy.h
+++ b/flecsi/topology/hpx/storage_policy.h
@@ -1,0 +1,119 @@
+/*~--------------------------------------------------------------------------~*
+ * Copyright (c) 2015 Los Alamos National Security, LLC
+ * All rights reserved.
+ *~--------------------------------------------------------------------------~*/
+
+#ifndef flecsi_topology_hpx_topology_storage_policy_h
+#define flecsi_topology_hpx_topology_storage_policy_h
+
+#include "flecsi/topology/mesh_storage.h"
+
+#include <array>
+#include <cassert>
+#include <iostream>
+#include <unordered_map>
+#include <vector>
+
+#include <flecsi/data/data_client.h>
+#include <flecsi/execution/context.h>
+#include <flecsi/topology/common/entity_storage.h>
+#include <flecsi/topology/index_space.h>
+#include <flecsi/topology/mesh_storage.h>
+#include <flecsi/topology/mesh_types.h>
+#include <flecsi/topology/mesh_utils.h>
+
+///
+/// \file
+/// \date Initial file creation: Apr 04, 2017
+///
+
+namespace flecsi {
+namespace topology {
+
+class mesh_entity_base_;
+
+template<size_t, size_t>
+class mesh_entity_t;
+
+///
+/// \class hpx_data_handle_policy_t data_handle_policy.h
+/// \brief hpx_data_handle_policy_t provides...
+///
+
+template<size_t NUM_DIMS, size_t NUM_DOMS>
+struct hpx_topology_storage_policy__ {
+  static constexpr size_t num_partitions = 5;
+  using id_t = utils::id_t;
+
+  using index_spaces_t = std::array<
+      index_space__<
+          mesh_entity_base_ *,
+          true,
+          true,
+          true,
+          void,
+          topology_storage__>,
+      NUM_DIMS + 1>;
+
+  using partition_index_spaces_t = std::array<
+      index_space__<
+          mesh_entity_base_ *,
+          false,
+          false,
+          true,
+          void,
+          topology_storage__>,
+      NUM_DIMS + 1>;
+
+  // array of array of domain_connectivity__
+  std::array<std::array<domain_connectivity__<NUM_DIMS>, NUM_DOMS>, NUM_DOMS>
+      topology;
+
+  std::array<index_spaces_t, NUM_DOMS> index_spaces;
+
+  std::array<std::array<partition_index_spaces_t, NUM_DOMS>, num_partitions>
+      partition_index_spaces;
+
+  size_t color;
+
+  hpx_topology_storage_policy__() {
+    auto & context_ = flecsi::execution::context_t::instance();
+    color = context_.color();
+  }
+
+  template<size_t D, size_t N>
+  size_t entity_dimension(mesh_entity_t<D, N> *) {
+    return D;
+  }
+
+  template<class T, size_t M = 0, class... S>
+  T * make(S &&... args) {
+    T * ent;
+    size_t dim = entity_dimension(ent);
+    ent = new T(std::forward<S>(args)...);
+
+    using dtype = domain_entity<M, T>;
+
+    auto & is = index_spaces[M][dim].template cast<dtype>();
+
+    id_t global_id = id_t::make<M>(dim, is.size());
+
+    auto typed_ent = static_cast<mesh_entity_base_t<NM> *>(ent);
+
+    typed_ent->template set_global_id<M>(global_id);
+    is.push_back(ent);
+
+    return ent;
+  } // make
+
+}; // class hpx_topology_storage_policy_t
+
+} // namespace topology
+} // namespace flecsi
+
+#endif // flecsi_topology_hpx_topology_storage_policy_h
+
+/*~-------------------------------------------------------------------------~-*
+ * Formatting options for vim.
+ * vim: set tabstop=2 shiftwidth=2 expandtab :
+ *~-------------------------------------------------------------------------~-*/

--- a/flecsi/topology/index_space.h
+++ b/flecsi/topology/index_space.h
@@ -91,8 +91,14 @@ public:
   //! ID storage type
   using id_storage_t = ID_STORAGE_TYPE<id_t>;
 
+  template<typename T_, typename... Ts>
+  using id_storage_type_arg = ID_STORAGE_TYPE<T_>;
+
   //! Storage type
   using storage_t = STORAGE_TYPE<T>;
+
+  template<typename T_, typename... Ts>
+  using storage_type_arg = STORAGE_TYPE<T_>;
 
   //! item, e.g. entity type
   using item_t = typename std::remove_pointer<T>::type;
@@ -554,8 +560,9 @@ public:
       bool OWNED2 = OWNED,
       bool SORTED2 = SORTED,
       class F2 = F,
-      template<typename, typename...> class ID_STORAGE_TYPE2 = ID_STORAGE_TYPE,
-      template<typename, typename...> class STORAGE_TYPE2 = STORAGE_TYPE>
+      template<typename, typename...>
+      class ID_STORAGE_TYPE2 = id_storage_type_arg,
+      template<typename, typename...> class STORAGE_TYPE2 = storage_type_arg>
   auto & cast() {
     static_assert(std::is_convertible<S, T>::value, "invalid index space cast");
 
@@ -576,8 +583,9 @@ public:
       bool OWNED2 = OWNED,
       bool SORTED2 = SORTED,
       class F2 = F,
-      template<typename, typename...> class ID_STORAGE_TYPE2 = ID_STORAGE_TYPE,
-      template<typename, typename...> class STORAGE_TYPE2 = STORAGE_TYPE>
+      template<typename, typename...>
+      class ID_STORAGE_TYPE2 = id_storage_type_arg,
+      template<typename, typename...> class STORAGE_TYPE2 = storage_type_arg>
   auto & cast() const {
     static_assert(std::is_convertible<S, T>::value, "invalid index space cast");
 
@@ -1314,7 +1322,7 @@ public:
   }
 
   //-----------------------------------------------------------------//
-  //! Append another index space’s entities to the index space.
+  //! Append another index space's entities to the index space.
   //! If the index space does not have storage then only the indices
   //! are appended. It will create a copy of its aliased indices if
   //! OWNED is false.

--- a/flecsi/topology/mesh_topology.h
+++ b/flecsi/topology/mesh_topology.h
@@ -548,7 +548,7 @@ public:
     class ENT_TYPE>
   const auto entities(const ENT_TYPE * e) const {
 
-    const connectivity_t & c = 
+    const connectivity_t & c =
       get_connectivity(FROM_DOM, TO_DOM, ENT_TYPE::dimension, DIM);
     assert(!c.empty() && "empty connectivity");
 
@@ -573,7 +573,7 @@ public:
   template<size_t DIM, size_t FROM_DOM, size_t TO_DOM = FROM_DOM,
     class ENT_TYPE>
   auto entities(ENT_TYPE * e) {
-    connectivity_t & c = 
+    connectivity_t & c =
       get_connectivity(FROM_DOM, TO_DOM, ENT_TYPE::dimension, DIM);
     assert(!c.empty() && "empty connectivity");
 
@@ -707,7 +707,7 @@ public:
   template<size_t DIM, size_t FROM_DOM = 0, size_t TO_DOM = FROM_DOM,
     class ENT_TYPE>
   auto entity_ids(const ENT_TYPE * e) const {
-    const connectivity_t & c = 
+    const connectivity_t & c =
       get_connectivity(FROM_DOM, TO_DOM, ENT_TYPE::dimension, DIM);
     assert(!c.empty() && "empty connectivity");
     return c.get_index_space().ids(c.range(e->template id<FROM_DOM>()));
@@ -934,23 +934,23 @@ public:
     uint32_t num_dimensions;
     std::memcpy(&num_dimensions, buf + pos, sizeof(num_dimensions));
     pos += sizeof(num_dimensions);
-    assert(num_dimensions == MESH_TYPE::num_dimensions && 
+    assert(num_dimensions == MESH_TYPE::num_dimensions &&
       "dimension size mismatch");
 
     unserialize_domains_<
         storage_t, MESH_TYPE, MESH_TYPE::num_domains, MESH_TYPE::num_dimensions,
         0>::unserialize(*this, buf, pos);
 
-    for (size_t from_domain = 0; from_domain < MESH_TYPE::num_domains; 
+    for (size_t from_domain = 0; from_domain < MESH_TYPE::num_domains;
          ++from_domain) {
-      for (size_t to_domain = 0; to_domain < MESH_TYPE::num_domains; 
+      for (size_t to_domain = 0; to_domain < MESH_TYPE::num_domains;
            ++to_domain) {
 
         auto & dc = base_t::ms_->topology[from_domain][to_domain];
 
-        for (size_t from_dim = 0; from_dim <= MESH_TYPE::num_dimensions; 
+        for (size_t from_dim = 0; from_dim <= MESH_TYPE::num_dimensions;
              ++from_dim) {
-          for (size_t to_dim = 0; to_dim <= MESH_TYPE::num_dimensions; 
+          for (size_t to_dim = 0; to_dim <= MESH_TYPE::num_dimensions;
                ++to_dim) {
             connectivity_t & c = dc.get(from_dim, to_dim);
 
@@ -989,13 +989,13 @@ public:
 
 private:
   template<size_t, size_t, class>
-  friend class compute_connectivity__;
+  friend struct compute_connectivity__;
 
   template<size_t, size_t, class>
-  friend class compute_bindings__;
+  friend struct compute_bindings__;
 
   template<size_t DOM, typename VERT_TYPE>
-  void init_cell_(entity_type<MESH_TYPE::num_dimensions, DOM> * cell, 
+  void init_cell_(entity_type<MESH_TYPE::num_dimensions, DOM> * cell,
                   VERT_TYPE && verts) {
     auto & c = get_connectivity_(DOM, MESH_TYPE::num_dimensions, 0);
 
@@ -1072,7 +1072,7 @@ private:
         UsingDimension <= MESH_TYPE::num_dimensions,
         "UsingDimension must be <= total number of dimensions");
     static_assert(
-        Domain < MESH_TYPE::num_domains, 
+        Domain < MESH_TYPE::num_domains,
         "Domain must be < total number of domains");
 
     // Reference to storage from cells to the entity (to be created here).
@@ -1380,7 +1380,7 @@ private:
     // std::cerr << "intersect: " << FROM_DIM << " -> " << TO_DIM << std::endl;
 
     // The connectivity we will be populating
-    connectivity_t & out_conn = 
+    connectivity_t & out_conn =
       get_connectivity_(FROM_DOM, TO_DOM, FROM_DIM, TO_DIM);
     if (!out_conn.empty()) {
       return;
@@ -1652,7 +1652,7 @@ private:
     //           <<  ", dim " << FROM_DIM << " -> " << TO_DIM << std::endl;
 
     // check if requested connectivity is already there, nothing to do
-    connectivity_t & out_conn = 
+    connectivity_t & out_conn =
       get_connectivity_(FROM_DOM, TO_DOM, FROM_DIM, TO_DIM);
 
     if (!out_conn.empty())
@@ -1734,7 +1734,7 @@ private:
       for (size_t i = 0; i < n; ++i) {
         size_t m = sv[i];
 
-        id_t create_id = 
+        id_t create_id =
           id_t::make<TO_DIM, TO_DOM>(entity_id, cell_id.partition());
 
         // Add this id to the cell entity connections
@@ -1768,7 +1768,7 @@ private:
           }
         }
 
-        auto ent = 
+        auto ent =
           MESH_TYPE::template create_entity<TO_DOM, TO_DIM>(this, num_vertices);
 
         ++entity_id;

--- a/flecsi/topology/mesh_types.h
+++ b/flecsi/topology/mesh_types.h
@@ -17,6 +17,7 @@
 
 #include <array>
 #include <cassert>
+#include <cstdint>
 #include <iostream>
 #include <unordered_map>
 #include <vector>
@@ -159,7 +160,7 @@ using entity_vector_t = std::vector<mesh_entity_base__<NUM_DOMAINS> *>;
 //-----------------------------------------------------------------//
 //! \class domain_entity__ mesh_types.h
 //!
-//! \brief domain_entity__ is a simple wrapper to mesh entity that 
+//! \brief domain_entity__ is a simple wrapper to mesh entity that
 //! associates with its a domain id
 //!
 //! \tparam DOM Domain
@@ -305,7 +306,7 @@ public:
         index_space_.batch_push_(id);
       } // for
 
-      offsets_.add_count(iv.size());
+      offsets_.add_count(static_cast<std::uint32_t>(iv.size()));
     } // for
 
     index_space_.end_push_(start);
@@ -324,7 +325,7 @@ public:
     uint64_t size = 0;
 
     for (size_t i = 0; i < n; ++i) {
-      uint32_t count = num_conns[i];
+      uint32_t count = static_cast<std::uint32_t>(num_conns[i]);
       offsets_.add_count(count);
       size += count;
     } // for

--- a/flecsi/topology/types.h
+++ b/flecsi/topology/types.h
@@ -59,7 +59,7 @@ struct id_vector_hash_t {
   size_t operator()(const id_vector_t & v) const {
     size_t h = 0;
     for (utils::id_t id : v) {
-      h |= id.local_id();
+      h |= static_cast<size_t>(id.local_id());
     } // for
 
     return h;

--- a/flecsi/utils/CMakeLists.txt
+++ b/flecsi/utils/CMakeLists.txt
@@ -81,6 +81,11 @@ elseif(FLECSI_RUNTIME_MODEL STREQUAL "mpi")
   set(UNIT_POLICY MPI)
   set(RUNTIME_DRIVER ../execution/mpi/runtime_driver.cc)
 
+elseif(FLECSI_RUNTIME_MODEL STREQUAL "hpx")
+
+  set(UNIT_POLICY HPX)
+  set(RUNTIME_DRIVER ../execution/hpx/runtime_driver.cc)
+
 endif()
 
 #------------------------------------------------------------------------------#

--- a/flecsi/utils/array_ref.h
+++ b/flecsi/utils/array_ref.h
@@ -169,7 +169,7 @@ public:
     return length_;
   }
   constexpr size_type max_size() const {
-    return std::numeric_limits<size_type>::max() / sizeof(T);
+    return (std::numeric_limits<size_type>::max)() / sizeof(T);
   }
   constexpr bool empty() const {
     return length_ == 0;

--- a/flecsi/utils/common.h
+++ b/flecsi/utils/common.h
@@ -106,7 +106,7 @@ type() {
 //! Generate unique ids
 template<
     typename T,
-    std::size_t MAXIMUM = std::numeric_limits<std::size_t>::max()>
+    std::size_t MAXIMUM = (std::numeric_limits<std::size_t>::max)()>
 struct unique_id_t {
   static unique_id_t & instance() {
     static unique_id_t u;

--- a/flecsi/utils/dbc_impl.h
+++ b/flecsi/utils/dbc_impl.h
@@ -15,6 +15,7 @@
 
 /*! @file */
 
+#include <flecsi/utils/export_definitions.h>
 
 #ifndef IM_OK_TO_INCLUDE_DBC_IMPL
 #warning                                                                       \
@@ -33,17 +34,17 @@ using action_t =
     std::function<void(std::string const &, const char *, const char *, int)>;
 
 /**\brief Constructs error/exception message */
-std::string build_message(
+FLECSI_EXPORT std::string build_message(
     std::string const & cond,
     const char * file_name,
     const char * func_name,
     int line);
 
 /**\brief Stream used for error reporting, defaults to std::cerr. */
-extern std::ostream * p_str;
+FLECSI_EXPORT extern std::ostream *p_str;
 
 /**\brief Core assertion function. */
-bool assertf(
+FLECSI_EXPORT bool assertf(
     bool cond,
     std::string const & cond_str,
     const char * file_name,

--- a/flecsi/utils/debruijn.h
+++ b/flecsi/utils/debruijn.h
@@ -62,7 +62,14 @@ public:
     // 2. *  Shift and truncate the sequence by the isolated bit index
     // 3. >> Shift off all but the high log_2(32) bits to get the lookup index
     // 4. [] return the index from the lookup table
+#if defined(_MSC_VER)
+#pragma warning (push)
+#pragma warning (disable: 4146) // unary minus operator applied to unsigned type, result still unsigned
+#endif
     return index_[(b & -b) * seq_ >> 27];
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
   } // index
 
 }; // debruijn32_t

--- a/flecsi/utils/export_definitions.h
+++ b/flecsi/utils/export_definitions.h
@@ -1,0 +1,58 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(FLECSI_EXPORT_DEFINITIONS)
+#define FLECSI_EXPORT_DEFINITIONS
+
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
+# define FLECSI_SYMBOL_EXPORT      __declspec(dllexport)
+# define FLECSI_SYMBOL_IMPORT      __declspec(dllimport)
+# define FLECSI_SYMBOL_INTERNAL    /* empty */
+# define FLECSI_APISYMBOL_EXPORT   __declspec(dllexport)
+# define FLECSI_APISYMBOL_IMPORT   __declspec(dllimport)
+#elif defined(__NVCC__) || defined(__CUDACC__)
+# define FLECSI_SYMBOL_EXPORT      /* empty */
+# define FLECSI_SYMBOL_IMPORT      /* empty */
+# define FLECSI_SYMBOL_INTERNAL    /* empty */
+# define FLECSI_APISYMBOL_EXPORT   /* empty */
+# define FLECSI_APISYMBOL_IMPORT   /* empty */
+#elif defined(FLECSI_HAVE_ELF_HIDDEN_VISIBILITY)
+# define FLECSI_SYMBOL_EXPORT      __attribute__((visibility("default")))
+# define FLECSI_SYMBOL_IMPORT      __attribute__((visibility("default")))
+# define FLECSI_SYMBOL_INTERNAL    __attribute__((visibility("hidden")))
+# define FLECSI_APISYMBOL_EXPORT   __attribute__((visibility("default")))
+# define FLECSI_APISYMBOL_IMPORT   __attribute__((visibility("default")))
+#endif
+
+// make sure we have reasonable defaults
+#if !defined(FLECSI_SYMBOL_EXPORT)
+# define FLECSI_SYMBOL_EXPORT      /* empty */
+#endif
+#if !defined(FLECSI_SYMBOL_IMPORT)
+# define FLECSI_SYMBOL_IMPORT      /* empty */
+#endif
+#if !defined(FLECSI_SYMBOL_INTERNAL)
+# define FLECSI_SYMBOL_INTERNAL    /* empty */
+#endif
+#if !defined(FLECSI_APISYMBOL_EXPORT)
+# define FLECSI_APISYMBOL_EXPORT   /* empty */
+#endif
+#if !defined(FLECSI_APISYMBOL_IMPORT)
+# define FLECSI_APISYMBOL_IMPORT   /* empty */
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+// define the export/import helper macros used by the runtime module
+#if defined(FLECSI_EXPORTS) || defined(FleCSI_EXPORTS)
+# define  FLECSI_EXPORT             FLECSI_SYMBOL_EXPORT
+# define  FLECSI_EXCEPTION_EXPORT   FLECSI_SYMBOL_EXPORT
+# define  FLECSI_API_EXPORT         FLECSI_APISYMBOL_EXPORT
+#else
+# define  FLECSI_EXPORT             FLECSI_SYMBOL_IMPORT
+# define  FLECSI_EXCEPTION_EXPORT   FLECSI_SYMBOL_IMPORT
+# define  FLECSI_API_EXPORT         FLECSI_APISYMBOL_IMPORT
+#endif
+
+#endif

--- a/flecsi/utils/hash.h
+++ b/flecsi/utils/hash.h
@@ -90,7 +90,7 @@ field_hash(size_t version) {
 
 inline size_t
 field_hash(size_t nspace, size_t name, size_t version) {
-  return ((nspace ^ name) << field_hash_version_bits | version) & ~(1ul << 63);
+  return ((nspace ^ name) << field_hash_version_bits | version) & ~(1ull << 63);
 } // field_hash
 
 inline constexpr size_t
@@ -107,7 +107,7 @@ field_hash_version(size_t key) {
 //----------------------------------------------------------------------------//
 
 bool inline is_internal(size_t key) {
-  return key & (1ul << 63);
+  return key & (1ull << 63);
 } // is_internal
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -295,12 +295,12 @@ client_adjacency_to_dimension(size_t key) {
 template<size_t NAME, size_t INDEX_SPACE>
 inline constexpr size_t
 client_internal_field_hash() {
-  return ((NAME << 8) | INDEX_SPACE) | (1ul << 63);
+  return ((NAME << 8) | INDEX_SPACE) | (1ull << 63);
 } // field_hash__
 
 inline size_t
 client_internal_field_hash(size_t name, size_t index_space) {
-  return ((name << 8) | index_space) | (1ul << 63);
+  return ((name << 8) | index_space) | (1ull << 63);
 } // field_hash__
 
 inline constexpr size_t

--- a/flecsi/utils/id.h
+++ b/flecsi/utils/id.h
@@ -15,6 +15,9 @@
 
 /*! @file */
 
+#if defined(_MSC_VER)
+#include "uint128.h"
+#endif
 
 #include <cassert>
 #include <climits>

--- a/flecsi/utils/uint128.h
+++ b/flecsi/utils/uint128.h
@@ -1,0 +1,466 @@
+//   Copyright: Copyright (C) 2005, Jan Ringos, http://Tringi.Mx-3.cz
+//   Version: 1.1
+//
+//  Copyright (c) 2014 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef UTIL_INTEGER_UINT128_HPP
+#define UTIL_INTEGER_UINT128_HPP
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <exception>
+#include <new>
+
+namespace flecsi {
+namespace utils {
+    ///////////////////////////////////////////////////////////////////////////
+    class uint128;
+
+    inline bool operator <  (const uint128 & a, const uint128 & b) noexcept;
+    inline bool operator == (const uint128 & a, const uint128 & b) noexcept;
+    inline bool operator || (const uint128 & a, const uint128 & b) noexcept;
+    inline bool operator && (const uint128 & a, const uint128 & b) noexcept;
+
+    // GLOBAL OPERATOR INLINES
+
+    inline uint128 operator + (const uint128 & a, const uint128 & b) noexcept;
+    inline uint128 operator - (const uint128 & a, const uint128 & b) noexcept;
+    inline uint128 operator * (const uint128 & a, const uint128 & b) noexcept;
+    inline uint128 operator / (const uint128 & a, const uint128 & b) noexcept;
+    inline uint128 operator % (const uint128 & a, const uint128 & b) noexcept;
+
+    inline uint128 operator >> (const uint128 & a, unsigned int n) noexcept;
+    inline uint128 operator << (const uint128 & a, unsigned int n) noexcept;
+
+    inline uint128 operator & (const uint128 & a, const uint128 & b) noexcept;
+    inline uint128 operator | (const uint128 & a, const uint128 & b) noexcept;
+    inline uint128 operator ^ (const uint128 & a, const uint128 & b) noexcept;
+
+    inline bool operator >  (const uint128 & a, const uint128 & b) noexcept;
+    inline bool operator <= (const uint128 & a, const uint128 & b) noexcept;
+    inline bool operator >= (const uint128 & a, const uint128 & b) noexcept;
+    inline bool operator != (const uint128 & a, const uint128 & b) noexcept;
+
+    ///////////////////////////////////////////////////////////////////////////
+    class uint128
+    {
+    private:
+        // Binary correct representation of unsigned 128bit integer
+        std::uint64_t lo;
+        std::uint64_t hi;
+
+    protected:
+        // Some global operator functions must be friends
+        friend bool operator <  (const uint128 &, const uint128 &) noexcept;
+        friend bool operator == (const uint128 &, const uint128 &) noexcept;
+        friend bool operator || (const uint128 &, const uint128 &) noexcept;
+        friend bool operator && (const uint128 &, const uint128 &) noexcept;
+
+    public:
+        // Constructors
+        inline uint128 () noexcept : lo(0ull), hi(0ull) {}
+
+        inline uint128 (int a) noexcept : lo (a), hi (0ull) {}
+        inline uint128 (unsigned int a) noexcept : lo (a), hi (0ull) {}
+        inline uint128 (std::uint64_t a) noexcept : lo (a), hi (0ull) {}
+
+        uint128 (float a) noexcept
+          : lo ((std::uint64_t) fmodf (a, 18446744073709551616.0f)),
+            hi ((std::uint64_t) (a / 18446744073709551616.0f)) {}
+        uint128 (double a) noexcept
+          : lo ((std::uint64_t) fmod (a, 18446744073709551616.0)),
+            hi ((std::uint64_t) (a / 18446744073709551616.0)) {}
+        uint128 (long double a) noexcept
+          : lo ((std::uint64_t) fmodl (a, 18446744073709551616.0l)),
+            hi ((std::uint64_t) (a / 18446744073709551616.0l)) {}
+
+        uint128 (const char * sz) noexcept : lo (0u), hi (0u) {
+            if (!sz) return;
+            if (!sz [0]) return;
+
+            unsigned int radix = 10;
+            std::size_t i = 0;
+            bool minus = false;
+
+            if (sz [i] == '-') {
+                ++i;
+                minus = true;
+            };
+
+            if (sz [i] == '0') {
+                radix = 8;
+                ++i;
+                if (sz [i] == 'x') {
+                    radix = 16;
+                    ++i;
+                };
+            };
+
+            std::size_t len = strlen (sz);
+            for (; i < len; ++i) {
+                unsigned int n = 0;
+                if (sz [i] >= '0' && sz [i] <= (std::min)(('0' + (int)radix), (int)'9'))
+                    n = sz [i] - '0';
+                else if (sz [i] >= 'a' && sz [i] <= 'a' + (int) radix - 10)
+                    n = sz [i] - 'a' + 10;
+                else if (sz [i] >= 'A' && sz [i] <= 'A' + (int) radix - 10)
+                    n = sz [i] - 'A' + 10;
+                else
+                    break;
+
+                (*this) *= radix;
+                (*this) += n;
+            };
+
+            if (minus)
+                *this = 0u - *this;
+        }
+
+        // TODO: Consider creation of operator= to eliminate
+        //       the need of intermediate objects during assignments.
+
+    private:
+        // Special internal constructors
+        uint128 (const std::uint64_t & a, const std::uint64_t & b) noexcept
+            : lo (a), hi (b) {}
+
+    public:
+        // Operators
+        bool operator ! () const noexcept {
+            return !(this->hi || this->lo);
+        }
+
+        uint128 operator - () const noexcept {
+            if (!this->hi && !this->lo)
+                // number is 0, just return 0
+                return *this;
+
+#pragma warning(push)
+#pragma warning(disable: 4146)
+            // non 0 number
+            return uint128 (-this->lo, ~this->hi);
+#pragma warning(pop)
+        }
+        uint128 operator ~ () const noexcept {
+            return uint128 (~this->lo, ~this->hi);
+        }
+
+        uint128 & operator ++ () {
+            ++this->lo;
+            if (!this->lo)
+                ++this->hi;
+
+            return *this;
+        }
+        uint128 & operator -- () {
+            if (!this->lo)
+                --this->hi;
+            --this->lo;
+
+            return *this;
+        }
+        uint128 operator ++ (int) {
+            uint128 b = *this;
+            ++ *this;
+
+            return b;
+        }
+        uint128 operator -- (int) {
+            uint128 b = *this;
+            -- *this;
+
+            return b;
+        }
+
+        uint128 & operator += (const uint128 & b) noexcept {
+            std::uint64_t old_lo = this->lo;
+
+            this->lo += b.lo;
+            this->hi += b.hi + (this->lo < old_lo);
+
+            return *this;
+        }
+        uint128 & operator *= (const uint128 & b) noexcept {
+            if (!b)
+                return *this = 0u;
+            if (b == 1u)
+                return *this;
+
+            uint128 a = *this;
+            uint128 t = b;
+
+            this->lo = 0ull;
+            this->hi = 0ull;
+
+            for (unsigned int i = 0; i < 128; ++i) {
+                if (t.lo & 1)
+                    *this += a << i;
+
+                t >>= 1;
+            };
+
+            return *this;
+        }
+
+        uint128 & operator >>= (unsigned int n) noexcept {
+            n &= 0x7F;
+
+            if (n > 63) {
+                n -= 64;
+                this->lo = this->hi;
+                this->hi = 0ull;
+            };
+
+            if (n) {
+                // shift low qword
+                this->lo >>= n;
+
+                // get lower N bits of high qword
+                std::uint64_t mask = 0ull;
+                for (unsigned int i = 0; i < n; ++i)
+                    mask |= (1ll << i);
+
+                // and add them to low qword
+                this->lo |= (this->hi & mask) << (64 - n);
+
+                // and finally shift also high qword
+                this->hi >>= n;
+            };
+
+            return *this;
+        }
+        uint128 & operator <<= (unsigned int n) noexcept {
+            n &= 0x7F;
+
+            if (n > 63) {
+                n -= 64;
+                this->hi = this->lo;
+                this->lo = 0ull;
+            };
+
+            if (n) {
+                // shift high qword
+                this->hi <<= n;
+
+                // get higher N bits of low qword
+                std::uint64_t mask = 0ull;
+                for (unsigned int i = 0; i < n; ++i)
+                    mask |= (1ll << (63 - i));
+
+                // and add them to high qword
+                this->hi |= (this->lo & mask) >> (64 - n);
+
+                // and finally shift also low qword
+                this->lo <<= n;
+            };
+
+            return *this;
+        }
+
+        uint128 & operator |= (const uint128 & b) noexcept {
+            this->hi |= b.hi;
+            this->lo |= b.lo;
+
+            return *this;
+        }
+        uint128 & operator &= (const uint128 & b) noexcept {
+            this->hi &= b.hi;
+            this->lo &= b.lo;
+
+            return *this;
+        }
+        uint128 & operator ^= (const uint128 & b) noexcept {
+            this->hi ^= b.hi;
+            this->lo ^= b.lo;
+
+            return *this;
+        }
+
+        explicit operator bool() const noexcept {
+            return lo || hi;
+        }
+
+        // Inline simple operators
+        inline const uint128 & operator + () const noexcept { return *this; };
+
+        // Rest of inline operators
+        inline uint128 & operator -= (const uint128 & b) noexcept {
+            return *this += (-b);
+        };
+        inline uint128 & operator /= (const uint128 & b) noexcept {
+            uint128 dummy;
+            *this = this->div (b, dummy);
+            return *this;
+        };
+        inline uint128 & operator %= (const uint128 & b) noexcept {
+            this->div (b, *this);
+            return *this;
+        };
+
+        explicit operator std::uint64_t() const noexcept {
+            return lo;
+        }
+
+        // Common methods
+        unsigned int toUint () const noexcept {
+            return (unsigned int) this->lo; };
+        std::uint64_t toUint64 () const noexcept {
+            return (std::uint64_t) this->lo; };
+        const char * toString (unsigned int radix = 10) const noexcept {
+            if (!*this) return "0";
+            if (radix < 2 || radix > 37) return "(invalid radix)";
+
+            static char sz [256];
+            std::memset (sz, 0, 256);
+
+            uint128 r;
+            uint128 ii = *this;
+            int i = 255;
+
+            while (!!ii && i) {
+                ii = ii.div (radix, r);
+                sz [--i] = r.toUint () + ((r.toUint () > 9) ? 'A' - 10 : '0');
+            };
+
+            return &sz [i];
+        }
+        float toFloat () const noexcept {
+            return (float) this->hi * 18446744073709551616.0f
+                 + (float) this->lo;
+        }
+        double toDouble () const noexcept {
+            return (double) this->hi * 18446744073709551616.0
+                 + (double) this->lo;
+        }
+        long double toLongDouble () const noexcept {
+            return (long double) this->hi * 18446744073709551616.0l
+                 + (long double) this->lo;
+        }
+
+        // Arithmetic methods
+        uint128  div (const uint128 & ds, uint128 & remainder) const noexcept {
+            if (!ds)
+                return 1u / (unsigned int) ds.lo;
+
+            uint128 dd = *this;
+
+            // only remainder
+            if (ds > dd) {
+                remainder = *this;
+                return std::uint64_t(0ull);
+            };
+
+            uint128 r = std::uint64_t(0ull);
+            uint128 q = std::uint64_t(0ull);
+        //    while (dd >= ds) { dd -= ds; q += 1; }; // extreme slow version
+
+            unsigned int b = 127;
+            while (r < ds) {
+                r <<= 1;
+                if (dd.bit (b--))
+                    r.lo |= 1;
+            };
+            ++b;
+
+            while (true)
+                if (r < ds) {
+                    if (!(b--)) break;
+
+                    r <<= 1;
+                    if (dd.bit (b))
+                        r.lo |= 1;
+
+                } else {
+                    r -= ds;
+                    q.bit (b, true);
+                };
+
+            remainder = r;
+            return q;
+        }
+
+        // Bit operations
+        bool    bit (unsigned int n) const noexcept {
+            n &= 0x7F;
+
+            if (n < 64)
+                return (this->lo & (1ull << n)) ? true : false;
+
+            return (this->hi & (1ull << (n - 64))) ? true : false;
+        }
+        void    bit (unsigned int n, bool val) noexcept {
+            n &= 0x7F;
+
+            if (val) {
+                if (n < 64) this->lo |= (1ull << n);
+                       else this->hi |= (1ull << (n - 64));
+            } else {
+                if (n < 64) this->lo &= ~(1ull << n);
+                       else this->hi &= ~(1ull << (n - 64));
+            };
+        }
+    }
+    #ifdef __GNUC__
+        __attribute__ ((__aligned__ (16), __packed__))
+    #endif
+    ;
+
+
+    // GLOBAL OPERATORS
+
+    inline bool operator <  (const uint128 & a, const uint128 & b) noexcept {
+        return (a.hi == b.hi) ? (a.lo < b.lo) : (a.hi < b.hi);
+    }
+    inline bool operator == (const uint128 & a, const uint128 & b) noexcept {
+        return a.hi == b.hi && a.lo == b.lo;
+    }
+    inline bool operator || (const uint128 & a, const uint128 & b) noexcept {
+        return (a.hi || a.lo) && (b.hi || b.lo);
+    }
+    inline bool operator && (const uint128 & a, const uint128 & b) noexcept {
+        return (a.hi || a.lo) || (b.hi || b.lo);
+    }
+
+    // GLOBAL OPERATOR INLINES
+
+    inline uint128 operator + (const uint128 & a, const uint128 & b) noexcept {
+        return uint128 (a) += b; };
+    inline uint128 operator - (const uint128 & a, const uint128 & b) noexcept {
+        return uint128 (a) -= b; };
+    inline uint128 operator * (const uint128 & a, const uint128 & b) noexcept {
+        return uint128 (a) *= b; };
+    inline uint128 operator / (const uint128 & a, const uint128 & b) noexcept {
+        return uint128 (a) /= b; };
+    inline uint128 operator % (const uint128 & a, const uint128 & b) noexcept {
+        return uint128 (a) %= b; };
+
+    inline uint128 operator >> (const uint128 & a, unsigned int n) noexcept {
+        return uint128 (a) >>= n; };
+    inline uint128 operator << (const uint128 & a, unsigned int n) noexcept {
+        return uint128 (a) <<= n; };
+
+    inline uint128 operator & (const uint128 & a, const uint128 & b) noexcept {
+        return uint128 (a) &= b; };
+    inline uint128 operator | (const uint128 & a, const uint128 & b) noexcept {
+        return uint128 (a) |= b; };
+    inline uint128 operator ^ (const uint128 & a, const uint128 & b) noexcept {
+        return uint128 (a) ^= b; };
+
+    inline bool operator >  (const uint128 & a, const uint128 & b) noexcept {
+        return   b < a; };
+    inline bool operator <= (const uint128 & a, const uint128 & b) noexcept {
+        return !(b < a); };
+    inline bool operator >= (const uint128 & a, const uint128 & b) noexcept {
+        return !(a < b); };
+    inline bool operator != (const uint128 & a, const uint128 & b) noexcept {
+        return !(a == b); };
+}}
+
+typedef flecsi::utils::uint128 __uint128_t;
+
+#endif

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -83,7 +83,9 @@ endforeach()
 
 string(STRIP "${FLECSIT_LIBRARIES}" FLECSIT_LIBRARIES)
 
-list(REMOVE_DUPLICATES FLECSI_LD_DEPENDS_LIST)
+if(FLECSI_LD_DEPENDS_LIST)
+  list(REMOVE_DUPLICATES FLECSI_LD_DEPENDS_LIST)
+endif()
 
 #------------------------------------------------------------------------------#
 # Process the list of path dependencies for environment module LD_LIBARRY_PATH
@@ -117,24 +119,24 @@ if(ENABLE_FLECSIT)
     # FleCSIT dependencies
     #--------------------------------------------------------------------------#
 
-	find_package(PythonInterp 2.7 REQUIRED)
+  find_package(PythonInterp 2.7 REQUIRED)
 
-	execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import distutils.sysconfig as cg; print cg.get_python_lib(0,0,prefix='${CMAKE_INSTALL_PREFIX}')" OUTPUT_VARIABLE PYTHON_INSTDIR OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import distutils.sysconfig as cg; print cg.get_python_lib(0,0,prefix='${CMAKE_INSTALL_PREFIX}')" OUTPUT_VARIABLE PYTHON_INSTDIR OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-	install(DIRECTORY ${CMAKE_SOURCE_DIR}/tools/flecsit/flecsit
-		DESTINATION ${PYTHON_INSTDIR}
-		FILES_MATCHING PATTERN "*.py")
+  install(DIRECTORY ${CMAKE_SOURCE_DIR}/tools/flecsit/flecsit
+    DESTINATION ${PYTHON_INSTDIR}
+    FILES_MATCHING PATTERN "*.py")
 
-	configure_file(${CMAKE_SOURCE_DIR}/tools/flecsit/bin/flecsit.in
-		${CMAKE_BINARY_DIR}/flecsit/bin/flecsit @ONLY)
+  configure_file(${CMAKE_SOURCE_DIR}/tools/flecsit/bin/flecsit.in
+    ${CMAKE_BINARY_DIR}/flecsit/bin/flecsit @ONLY)
 
-	install(PROGRAMS ${CMAKE_BINARY_DIR}/flecsit/bin/flecsit
-		DESTINATION bin
-		PERMISSIONS
-			OWNER_READ OWNER_WRITE OWNER_EXECUTE
-			GROUP_READ GROUP_EXECUTE
-			WORLD_READ WORLD_EXECUTE
-	)
+  install(PROGRAMS ${CMAKE_BINARY_DIR}/flecsit/bin/flecsit
+    DESTINATION bin
+    PERMISSIONS
+      OWNER_READ OWNER_WRITE OWNER_EXECUTE
+      GROUP_READ GROUP_EXECUTE
+      WORLD_READ WORLD_EXECUTE
+  )
 
     set(FLECSI_PYTHON_PATH_MODULE
         "prepend-path PYTHONPATH ${PYTHON_INSTDIR}"


### PR DESCRIPTION
- fixing warnings reported by MSVC
- Fix indentation
- Resolving rebase conflicts
- Making sure initialize() returns only after all activity has ceased
- Executing tasks using hpx::async
- started to implement tasks_and_drivers example
- Adapting to latest changes, directly execute tlt_driver before starting HPX
- Suppressing warnings
- Initialize HPX in context policy, run driver() as HPX thread
- simple_drivers is functional
- Add missing functions to uint128
- work around MSVC problems
- Duplicated serial runtime model to HPX
- added build system support for HPX
- flyby: various fixes for MSVC: added __uint128_t, exported symbols, minor workarounds