### PR TITLE
BUG: Fixed flecsit path issue in cmake configuration

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -125,7 +125,7 @@ if(ENABLE_FLECSIT)
 		DESTINATION ${PYTHON_INSTDIR}
 		FILES_MATCHING PATTERN "*.py")
 
-	configure_file(${CMAKE_SOURCE_DIR}/tools/flecsit/bin/flecsit.in
+	configure_file(${PROJECT_SOURCE_DIR}/tools/flecsit/bin/flecsit.in
 		${CMAKE_BINARY_DIR}/flecsit/bin/flecsit @ONLY)
 
 	install(PROGRAMS ${CMAKE_BINARY_DIR}/flecsit/bin/flecsit


### PR DESCRIPTION
A downstream observation when building flecsale master branch with this cmake command, when the latest commit hash of flecsi master is synced in:

`cmake .. -DCMAKE_BUILD_TYPE=Debug -DFLECSI_RUNTIME_MODEL=mpi -DENABLE_MPI=ON`

generates error output that includes:
```
-- Found PythonInterp: /home/tyler/miniconda3/envs/scipy_dev_py27/bin/python (found suitable version "2.7.14", minimum required is "2.7") 
CMake Error: File /home/tyler/github_projects/flecsale/tools/flecsit/bin/flecsit.in does not exist.
CMake Error at flecsi/tools/CMakeLists.txt:128 (configure_file):
  configure_file Problem configuring file
```

The adjustment in this PR branch appears to enable the above cmake command to run without errors.