### PR TITLE
DOC: minor typo fixes for data-clients tutorial

### DIFF
--- a/flecsi-tutorial/02-data-clients/data-clients.cc
+++ b/flecsi-tutorial/02-data-clients/data-clients.cc
@@ -41,8 +41,8 @@ using namespace flecsi::tutorial;
   specialization may expose several different mesh types and other
   specializations, and would likely have a different interface.
 
-  The registration interface for data clients tasks the following
-  arguemnts:
+  The registration interface for data clients takes the following
+  arguments:
 
   (1) The data client type. This must be a valid specialization type. In
       general, application developers and end-users will not create this


### PR DESCRIPTION
Minor typo fixes I noticed as I read through the tutorial.