### PR TITLE
Add BOOST_INCLUDEDIR to build directions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ can be done like this:
            -DFLECSI_RUNTIME_MODEL=legion \
            -DENABLE_MPI=ON \
            -DENABLE_PARMETIS=ON \
-           -DENABLE_COLORING=ON
+           -DENABLE_COLORING=ON \
+           -DBOOST_INCLUDEDIR=/path/to/boost/include
 
          make
 


### PR DESCRIPTION
Currently on Darwin, the default Boost module does not set any of the environment variables that CMake needs to pick it up.  So specify BOOST_INCLUDEDIR explicitly.