### PR TITLE
Msvc mpi runtime

### DIFF
--- a/config/project.cmake
+++ b/config/project.cmake
@@ -83,12 +83,15 @@ set_property(CACHE FLECSI_RUNTIME_MODEL
 if(FLECSI_RUNTIME_MODEL STREQUAL "mpi")
   set(ENABLE_MPI ON CACHE BOOL "Enable MPI" FORCE)
   set(ENABLE_LEGION OFF CACHE BOOL "Enable Legion" FORCE)
+  set(ENABLE_HPX OFF CACHE BOOL "Enable HPX" FORCE)
 elseif(FLECSI_RUNTIME_MODEL STREQUAL "legion")
   set(ENABLE_MPI ON CACHE BOOL "Enable MPI" FORCE)
   set(ENABLE_LEGION ON CACHE BOOL "Enable Legion" FORCE)
+  set(ENABLE_HPX OFF CACHE BOOL "Enable HPX" FORCE)
 elseif(FLECSI_RUNTIME_MODEL STREQUAL "hpx")
   set(ENABLE_MPI ON CACHE BOOL "Enable MPI" FORCE)
   set(ENABLE_HPX ON CACHE BOOL "Enable HPX" FORCE)
+  set(ENABLE_LEGION OFF CACHE BOOL "Enable Legion" FORCE)
 endif()
 
 mark_as_advanced(ENABLE_MPI ENABLE_LEGION)
@@ -433,6 +436,8 @@ if(ENABLE_FLECSI_TUTORIAL)
   endif()
 
   cinch_add_library_target(FleCSI-Tut flecsi-tutorial/specialization)
+
+  set_target_properties(FleCSI-Tut PROPERTIES FOLDER "Tutorial")
 endif()
 
 #------------------------------------------------------------------------------#

--- a/examples/00_simple_drivers/CMakeLists.txt
+++ b/examples/00_simple_drivers/CMakeLists.txt
@@ -43,6 +43,8 @@ target_link_libraries(simple_drivers FleCSI ${FLECSI_RUNTIME_LIBRARIES})
 
 if(FLECSI_RUNTIME_MODEL STREQUAL "hpx")
   hpx_setup_target(simple_drivers FOLDER "Examples")
+else()
+  set_target_properties(simple_drivers PROPERTIES FOLDER "Examples")
 endif()
 
 #~---------------------------------------------------------------------------~-#

--- a/examples/02_tasks_and_drivers/CMakeLists.txt
+++ b/examples/02_tasks_and_drivers/CMakeLists.txt
@@ -27,13 +27,13 @@ if(FLECSI_RUNTIME_MODEL STREQUAL "legion" OR
   #----------------------------------------------------------------------------#
 
   set(exec_path ${PROJECT_SOURCE_DIR}/flecsi/execution)
-if(FLECSI_RUNTIME_MODEL STREQUAL "legion")
-  set (exmaple_src      tasks_and_drivers.cc
-                        ${exec_path}/legion/runtime_driver.cc)
-elseif(FLECSI_RUNTIME_MODEL STREQUAL "hpx")
-  set (exmaple_src      tasks_and_drivers.cc
-                        ${exec_path}/hpx/runtime_driver.cc)
-endif()
+  if(FLECSI_RUNTIME_MODEL STREQUAL "legion")
+    set (exmaple_src      tasks_and_drivers.cc
+                          ${exec_path}/legion/runtime_driver.cc)
+  elseif(FLECSI_RUNTIME_MODEL STREQUAL "hpx")
+    set (exmaple_src      tasks_and_drivers.cc
+                          ${exec_path}/hpx/runtime_driver.cc)
+  endif()
 
   #----------------------------------------------------------------------------#
   # Add a rule to build the executable
@@ -50,6 +50,8 @@ endif()
 
   if(FLECSI_RUNTIME_MODEL STREQUAL "hpx")
     hpx_setup_target(tasks_and_drivers FOLDER "Examples")
+  else()
+    set_target_properties(tasks_and_drivers PROPERTIES FOLDER "Examples")
   endif()
 
 endif()

--- a/flecsi/coloring/CMakeLists.txt
+++ b/flecsi/coloring/CMakeLists.txt
@@ -125,7 +125,7 @@ cinch_add_devel_target(devel-dcrs
   LIBRARIES ${COLORING_LIBRARIES}
   POLICY MPI
   THREADS 5
-  FOLDER "Tests/Coloring"
+  FOLDER "Tests/Coloring/Devel"
 )
 
 cinch_add_unit(boxcolor2d
@@ -158,7 +158,7 @@ cinch_add_devel_target(coloring
   LIBRARIES ${COLORING_LIBRARIES}
   POLICY MPI
   THREADS 5
-  FOLDER "Tests/Coloring"
+  FOLDER "Tests/Coloring/Devel"
 )
 
 endif()

--- a/flecsi/coloring/crs.h
+++ b/flecsi/coloring/crs.h
@@ -73,7 +73,7 @@ operator<<(std::ostream & stream, const crs_t & crs) {
 } // operator <<
 
 /*!
- This type is a container for distrinuted compressed-storage of sparse data.
+ This type is a container for distributed compressed-storage of sparse data.
 
  @var distribution The index ranges for each color.
 

--- a/flecsi/coloring/mpi_communicator.h
+++ b/flecsi/coloring/mpi_communicator.h
@@ -89,13 +89,19 @@ public:
       const std::set<size_t> & request_indices,
       size_t max_request_indices,
       int colors) {
+
+    if (request_indices.empty()) {
+      // avoid UB caused by dereferencing the first element of an empty vector below
+      return std::vector<size_t>{};
+    }
+
     // Pad the request indices with size_t max. We will then set
     // the indices of the actual request. Each rank that receives
     // the request will try to provide information about the
     // non size_t max values in the request. The others will
     // be ignored.
     std::vector<size_t> input_indices(
-        colors * max_request_indices, std::numeric_limits<size_t>::max());
+        colors * max_request_indices, (std::numeric_limits<size_t>::max)());
     std::vector<size_t> info_indices(colors * max_request_indices);
 
     for (size_t c(0); c < colors; ++c) {
@@ -112,8 +118,9 @@ public:
 
     // Send the request indices to all other ranks.
     int result = MPI_Alltoall(
-        &input_indices[0], max_request_indices, mpi_size_t_type,
-        &info_indices[0], max_request_indices, mpi_size_t_type, MPI_COMM_WORLD);
+        &input_indices[0], static_cast<int>(max_request_indices), mpi_size_t_type,
+        &info_indices[0], static_cast<int>(max_request_indices), mpi_size_t_type,
+        MPI_COMM_WORLD);
 
     return info_indices;
   } // get_info_indices
@@ -152,16 +159,16 @@ public:
     // non size_t max values in the request. The others will
     // be ignored.
     std::vector<size_t> input_indices(
-        colors * max_request_indices, std::numeric_limits<size_t>::max());
+        colors * max_request_indices, (std::numeric_limits<size_t>::max)());
     std::vector<size_t> info_indices(colors * max_request_indices);
-    info_indices =
-        get_info_indices(request_indices, max_request_indices, colors);
+    info_indices = get_info_indices(
+        request_indices, max_request_indices, static_cast<int>(colors));
 
     // For now, we need two arrays for each all-to-all communication:
     // One for rank ownership of the request indices, and one
     // for the offsets. We could probably combine these. However,
     // we would probably have to define a custom MPI type. It
-    // will only be worth the effort if this appraoch is slow.
+    // will only be worth the effort if this approach is slow.
     // The input offsets do not need to be initialized because
     // the information is available in the input_indices array.
     std::vector<size_t> input_offsets(colors * max_request_indices);
@@ -170,7 +177,7 @@ public:
     // Reset input indices to use to send back information
     std::fill(
         input_indices.begin(), input_indices.end(),
-        std::numeric_limits<size_t>::max());
+        (std::numeric_limits<size_t>::max)());
 
     // For the primary coloring, provide rank and entity information
     // on indices that are shared with other processes.
@@ -207,15 +214,22 @@ public:
       } // for
     } // for
 
+    if (input_indices.empty()) {
+      // avoid UB caused by dereferencing the first element of an empty vector below
+      return std::make_pair(local, std::set<entity_info_t>{});
+    }
+
     // Send the indices information back to all ranks.
     int result = MPI_Alltoall(
-        &input_indices[0], max_request_indices, mpi_size_t_type,
-        &info_indices[0], max_request_indices, mpi_size_t_type, MPI_COMM_WORLD);
+        &input_indices[0], static_cast<int>(max_request_indices),mpi_size_t_type,
+        &info_indices[0], static_cast<int>(max_request_indices), mpi_size_t_type,
+        MPI_COMM_WORLD);
 
     // Send the offsets information back to all ranks.
     result = MPI_Alltoall(
-        &input_offsets[0], max_request_indices, mpi_size_t_type,
-        &info_offsets[0], max_request_indices, mpi_size_t_type, MPI_COMM_WORLD);
+        &input_offsets[0], static_cast<int>(max_request_indices), mpi_size_t_type,
+        &info_offsets[0], static_cast<int>(max_request_indices), mpi_size_t_type,
+        MPI_COMM_WORLD);
 
     std::set<entity_info_t> remote;
 
@@ -232,7 +246,7 @@ public:
 
       for (size_t i(0); i < max_request_indices; ++i) {
 
-        if (ranks[i] != std::numeric_limits<size_t>::max()) {
+        if (ranks[i] != (std::numeric_limits<size_t>::max)()) {
           // If this is not size_t max, this rank answered our request
           // and we can set the information.
           remote.insert(entity_info_t(
@@ -274,15 +288,15 @@ public:
     // non size_t max values in the request. The others will
     // be ignored.
     std::vector<size_t> input_indices(
-        colors * max_request_indices, std::numeric_limits<size_t>::max());
+        colors * max_request_indices, (std::numeric_limits<size_t>::max)());
     std::vector<size_t> info_indices(colors * max_request_indices);
-    info_indices =
-        get_info_indices(request_indices, max_request_indices, colors);
+    info_indices = get_info_indices(
+        request_indices, max_request_indices, static_cast<int>(colors));
 
     // Reset input indices to use to send back information
     std::fill(
         input_indices.begin(), input_indices.end(),
-        std::numeric_limits<size_t>::max());
+        (std::numeric_limits<size_t>::max)());
 
     {
       clog_tag_guard(mpi_communicator);
@@ -305,7 +319,7 @@ public:
       // Create a set of the off-color request indices.
       std::set<size_t> intersection_set;
       for (size_t i(0); i < max_request_indices; ++i) {
-        if (info[i] != std::numeric_limits<size_t>::max()) {
+        if (info[i] != (std::numeric_limits<size_t>::max)()) {
           intersection_set.insert(info[i]);
         } // if
       } // for
@@ -353,8 +367,8 @@ public:
 
     size_t max_request_indices = get_max_request_size(local_indices.size());
 
-    auto info_indices =
-        get_info_indices(local_indices, max_request_indices, colors);
+    auto info_indices = get_info_indices(
+        local_indices, max_request_indices, static_cast<int>(colors));
 
     std::unordered_map<size_t, std::set<size_t>> entity_reduction_map;
 
@@ -366,7 +380,7 @@ public:
       // Create a set of the off-color request indices.
       std::set<size_t> reduction_set;
       for (size_t i(0); i < max_request_indices; ++i) {
-        if (info[i] != std::numeric_limits<size_t>::max()) {
+        if (info[i] != (std::numeric_limits<size_t>::max)()) {
           reduction_set.insert(info[i]);
         } // if
       } // for
@@ -416,7 +430,8 @@ public:
         rbuffers[r].resize(recv_cnts[r]);
         requests.push_back({});
         MPI_Irecv(
-            &rbuffers[r][0], recv_cnts[r], mpi_typetraits__<size_t>::type(), r,
+            &rbuffers[r][0], static_cast<int>(recv_cnts[r]),
+            mpi_typetraits__<size_t>::type(), static_cast<int>(r),
             0, MPI_COMM_WORLD, &requests[requests.size() - 1]);
       } // if
     } // for
@@ -430,7 +445,8 @@ public:
             std::back_inserter(sbuffers[r]));
 
         MPI_Send(
-            &sbuffers[r][0], send_cnts[r], mpi_typetraits__<size_t>::type(), r,
+            &sbuffers[r][0], static_cast<int>(send_cnts[r]),
+            mpi_typetraits__<size_t>::type(), static_cast<int>(r),
             0, MPI_COMM_WORLD);
       } // if
     } // for
@@ -443,7 +459,9 @@ public:
 
     // Wait on the receive operations
     std::vector<MPI_Status> status(requests.size());
-    MPI_Waitall(requests.size(), &requests[0], &status[0]);
+    if (!requests.empty()) {
+      MPI_Waitall(static_cast<int>(requests.size()), &requests[0], &status[0]);
+    }
 
     // Set the offsets for each requested index in the send buffer.
     for (size_t r(0); r < colors; ++r) {
@@ -468,7 +486,8 @@ public:
         rbuffers[r].resize(send_cnts[r], 0);
         requests.push_back({});
         MPI_Irecv(
-            &rbuffers[r][0], send_cnts[r], mpi_typetraits__<size_t>::type(), r,
+            &rbuffers[r][0], static_cast<int>(send_cnts[r]),
+            mpi_typetraits__<size_t>::type(), static_cast<int>(r),
             0, MPI_COMM_WORLD, &requests[requests.size() - 1]);
       } // if
     } // for
@@ -478,14 +497,17 @@ public:
       // If we received a request, prepare to send an answer.
       if (recv_cnts[r]) {
         MPI_Send(
-            &sbuffers[r][0], recv_cnts[r], mpi_typetraits__<size_t>::type(), r,
+            &sbuffers[r][0], static_cast<int>(recv_cnts[r]),
+            mpi_typetraits__<size_t>::type(), static_cast<int>(r),
             0, MPI_COMM_WORLD);
       } // if
     } // for
 
     // Wait on the receive operations
     status.resize(requests.size());
-    MPI_Waitall(requests.size(), &requests[0], &status[0]);
+    if (!requests.empty()) {
+      MPI_Waitall(static_cast<int>(requests.size()), &requests[0], &status[0]);
+    }
 
     std::vector<std::set<size_t>> remote(colors);
     for (size_t r(0); r < colors; ++r) {
@@ -550,21 +572,22 @@ public:
     // non size_t max values in the request. The others will
     // be ignored.
     std::vector<size_t> info_indices(colors * max_request_indices);
-    info_indices =
-        get_info_indices(request_indices, max_request_indices, colors);
+    info_indices = get_info_indices(
+        request_indices, max_request_indices, static_cast<int>(colors));
 
-    for (size_t c(0); c < colors; ++c) {
+    if (!info_indices.empty()) {
+      for (size_t c(0); c < colors; ++c) {
 
-      size_t * info = &info_indices[c * max_request_indices];
+        size_t * info = &info_indices[c * max_request_indices];
 
-      for (size_t i(0); i < max_request_indices; ++i) {
-        if (info[i] != std::numeric_limits<size_t>::max()) {
-          const size_t value = info[i];
-          function(c, value);
-        } // if
+        for (size_t i(0); i < max_request_indices; ++i) {
+          if (info[i] != (std::numeric_limits<size_t>::max)()) {
+            const size_t value = info[i];
+            function(c, value);
+          } // if
+        } // for
       } // for
-    } // for
-
+    }
   } // alltoall_coloring_info
 
   /*!
@@ -586,11 +609,11 @@ public:
       size_t ghost;
     }; // struct size_info_t
 
-    size_info_t buffer[colors];
+    std::unique_ptr<size_info_t[]> buffer(new size_info_t[colors]);
     const size_t bytes = sizeof(size_info_t);
 
     int result = MPI_Allgather(
-        &color_info, bytes, MPI_BYTE, &buffer, bytes, MPI_BYTE, MPI_COMM_WORLD);
+        &color_info, bytes, MPI_BYTE, buffer.get(), bytes, MPI_BYTE, MPI_COMM_WORLD);
 
     std::unordered_map<size_t, coloring_info_t> coloring_info;
 

--- a/flecsi/coloring/parmetis_colorer.h
+++ b/flecsi/coloring/parmetis_colorer.h
@@ -147,7 +147,7 @@ struct parmetis_colorer_t : public colorer_t {
 
       for (size_t i(0); i < dcrs.size(); ++i) {
         if (part[i] == r) {
-          indices.push_back(static_cast<MPI_Request>(vtxdist[rank] + i));
+          indices.push_back(static_cast<idx_t>(vtxdist[rank] + i));
         } else if (part[i] == rank) {
           // If the index belongs to us, just add it...
           primary.insert(vtxdist[rank] + i);
@@ -155,7 +155,7 @@ struct parmetis_colorer_t : public colorer_t {
       } // for
 
       sbuffers.push_back(indices);
-      send_cnts[r] = static_cast<MPI_Request>(indices.size());
+      send_cnts[r] = static_cast<idx_t>(indices.size());
     } // for
 
 #if 0

--- a/flecsi/control/CMakeLists.txt
+++ b/flecsi/control/CMakeLists.txt
@@ -38,4 +38,5 @@ cinch_add_unit(control
     test/control.cc
   LIBRARIES
     ${FLECSI_LIBRARY_DEPENDENCIES}
+  FOLDER "Tests/Control"
 )

--- a/flecsi/control/test/control.cc
+++ b/flecsi/control/test/control.cc
@@ -5,13 +5,15 @@
 
 #include <bitset>
 #include <tuple>
+#include <thread>
+#include <chrono>
 
 #include <cinchtest.h>
 #include <flecsi/control/control.h>
 #include <flecsi/control/phase_walker.h>
 
 /*----------------------------------------------------------------------------*
- * Define simulation phases. This is considered part of the specializeation.
+ * Define simulation phases. This is considered part of the specialization.
  *----------------------------------------------------------------------------*/
 
 enum simulation_phases_t : size_t {
@@ -120,7 +122,7 @@ using graphviz_t = flecsi::utils::graphviz_t;
 
 #define define_action(name)                                                    \
   int action_##name(int argc, char ** argv) {                                  \
-    usleep(200000);                                                            \
+    std::this_thread::sleep_for(std::chrono::microseconds(200));               \
     std::cout << "target_" << #name << std::endl;                              \
     return 0;                                                                  \
   }

--- a/flecsi/data/mpi/data_client_handle_policy.h
+++ b/flecsi/data/mpi/data_client_handle_policy.h
@@ -57,14 +57,14 @@ struct data_client_handle_adjacency_t
   field_id_t index_fid;
   field_id_t offset_fid;
   size_t * offsets_buf;
-  id_t * indices_buf;
+  utils::id_t * indices_buf;
 };
 
 struct data_client_handle_index_subspace_t {
   size_t index_space;
   size_t index_subspace;
   field_id_t index_fid;
-  id_t * indices_buf;
+  utils::id_t * indices_buf;
   size_t domain;
   size_t dim;
 };

--- a/flecsi/data/mpi/dense.h
+++ b/flecsi/data/mpi/dense.h
@@ -93,7 +93,7 @@ struct dense_handle_t : public dense_data_handle__<T, EP, SP, GP>
   dense_handle_t() {}
 
   template<typename, size_t, size_t, size_t>
-  friend class dense_handle_t;
+  friend struct dense_handle_t;
 }; // struct dense_handle_t
 
 //+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=//

--- a/flecsi/data/mpi/sparse.h
+++ b/flecsi/data/mpi/sparse.h
@@ -82,7 +82,7 @@ struct sparse_handle__ : public sparse_data_handle__<T, EP, SP, GP>
   : base(num_exclusive, num_shared, num_ghost){}
 
   template<typename, size_t, size_t, size_t>
-  friend class sparse_handle__;
+  friend struct sparse_handle__;
 }; // struct sparse_handle__
 
 //+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=//

--- a/flecsi/execution/CMakeLists.txt
+++ b/flecsi/execution/CMakeLists.txt
@@ -249,6 +249,7 @@ cinch_add_unit(future_handle
         "Tests/Execution/Devel"
     )
 
+  if(NOT FLECSI_RUNTIME_MODEL STREQUAL "hpx")
     cinch_add_devel_target(devel_handle
       SOURCES
         test/devel_handle.cc
@@ -295,7 +296,6 @@ cinch_add_unit(future_handle
         "Tests/Execution/Devel"
     )
 
-  if(NOT FLECSI_RUNTIME_MODEL STREQUAL "hpx")
     # cinch_add_unit(forall
     #   SOURCES
     #     test/forall.fcc
@@ -480,7 +480,7 @@ cinch_add_unit(future_handle
       FOLDER
         "Tests/Execution"
     )
-    
+
     cinch_add_unit(sparse_data
         SOURCES
         test/sparse_data.cc
@@ -506,7 +506,7 @@ cinch_add_unit(future_handle
         FOLDER
           "Tests/Execution"
       )
-    
+
     cinch_add_unit(ragged_data
         SOURCES
         test/ragged_data.cc

--- a/flecsi/execution/CMakeLists.txt
+++ b/flecsi/execution/CMakeLists.txt
@@ -246,10 +246,9 @@ cinch_add_unit(future_handle
         -DFLECSI_8_8_MESH
       POLICY ${UNIT_POLICY}
       FOLDER
-        "Tests/Execution"
+        "Tests/Execution/Devel"
     )
 
-  if(NOT FLECSI_RUNTIME_MODEL STREQUAL "hpx")
     cinch_add_devel_target(devel_handle
       SOURCES
         test/devel_handle.cc
@@ -269,6 +268,8 @@ cinch_add_unit(future_handle
         -DCINCH_OVERRIDE_DEFAULT_INITIALIZATION_DRIVER
         -DFLECSI_8_8_MESH
       POLICY ${UNIT_POLICY}
+      FOLDER
+        "Tests/Execution/Devel"
     )
 
     cinch_add_devel_target(index_subspaces
@@ -290,8 +291,11 @@ cinch_add_unit(future_handle
         -DCINCH_OVERRIDE_DEFAULT_INITIALIZATION_DRIVER
         -DFLECSI_8_8_MESH
       POLICY ${UNIT_POLICY}
+      FOLDER
+        "Tests/Execution/Devel"
     )
 
+  if(NOT FLECSI_RUNTIME_MODEL STREQUAL "hpx")
     # cinch_add_unit(forall
     #   SOURCES
     #     test/forall.fcc
@@ -333,6 +337,8 @@ cinch_add_unit(future_handle
       POLICY ${UNIT_POLICY}
       THREADS 2
       NOCI
+      FOLDER
+        "Tests/Execution"
     )
 
     cinch_add_unit(handle_accessor
@@ -354,6 +360,8 @@ cinch_add_unit(future_handle
       POLICY ${UNIT_POLICY}
       THREADS 2
       NOCI
+      FOLDER
+        "Tests/Execution"
     )
 
     cinch_add_unit(ghost_access
@@ -375,6 +383,8 @@ cinch_add_unit(future_handle
       POLICY ${UNIT_POLICY}
       THREADS 2
       NOCI
+      FOLDER
+        "Tests/Execution"
     )
 
     cinch_add_unit(unordered_ispaces
@@ -394,6 +404,8 @@ cinch_add_unit(future_handle
         -DCINCH_OVERRIDE_DEFAULT_INITIALIZATION_DRIVER
       POLICY ${UNIT_POLICY}
       NOCI
+      FOLDER
+        "Tests/Execution"
     )
 
     cinch_add_unit(data_client_handle
@@ -418,6 +430,8 @@ cinch_add_unit(future_handle
       POLICY ${UNIT_POLICY}
       THREADS 2
       NOCI
+      FOLDER
+        "Tests/Execution"
     )
 
     cinch_add_unit(dense_data
@@ -442,6 +456,8 @@ cinch_add_unit(future_handle
       POLICY ${UNIT_POLICY}
       THREADS 2
       NOCI
+      FOLDER
+        "Tests/Execution"
     )
 
     cinch_add_unit(global_data
@@ -461,54 +477,60 @@ cinch_add_unit(future_handle
       POLICY ${UNIT_POLICY}
       THREADS 2
       NOCI
+      FOLDER
+        "Tests/Execution"
     )
     
     cinch_add_unit(sparse_data
-      SOURCES
+        SOURCES
         test/sparse_data.cc
         ../supplemental/coloring/add_colorings.cc
-        ${DRIVER_INITIALIZATION}
-        ${RUNTIME_DRIVER}
+          ${DRIVER_INITIALIZATION}
+          ${RUNTIME_DRIVER}
       INPUTS
         test/simple2d-8x8.msh
         test/simple2d-16x16.msh
         test/sparse_data.blessed
-      LIBRARIES
-        FleCSI
-        ${CINCH_RUNTIME_LIBRARIES}
-        ${COLORING_LIBRARIES}
-      DEFINES
-        -DFLECSI_ENABLE_SPECIALIZATION_TLT_INIT
-        -DFLECSI_ENABLE_SPECIALIZATION_SPMD_INIT
-        -DCINCH_OVERRIDE_DEFAULT_INITIALIZATION_DRIVER
+        LIBRARIES
+            FleCSI
+          ${CINCH_RUNTIME_LIBRARIES}
+          ${COLORING_LIBRARIES}
+        DEFINES
+          -DFLECSI_ENABLE_SPECIALIZATION_TLT_INIT
+          -DFLECSI_ENABLE_SPECIALIZATION_SPMD_INIT
+          -DCINCH_OVERRIDE_DEFAULT_INITIALIZATION_DRIVER
         -DFLECSI_8_8_MESH
-      POLICY ${UNIT_POLICY}
-      THREADS 2
-      NOCI
-    )
+        POLICY ${UNIT_POLICY}
+        THREADS 2
+        NOCI
+        FOLDER
+          "Tests/Execution"
+      )
     
     cinch_add_unit(ragged_data
-      SOURCES
+        SOURCES
         test/ragged_data.cc
-        ../supplemental/coloring/add_colorings.cc
-        ${DRIVER_INITIALIZATION}
-        ${RUNTIME_DRIVER}
-      INPUTS
-        test/simple2d-8x8.msh
-        test/simple2d-16x16.msh
-      LIBRARIES
-        FleCSI
-        ${CINCH_RUNTIME_LIBRARIES}
-        ${COLORING_LIBRARIES}
-      DEFINES
-        -DFLECSI_ENABLE_SPECIALIZATION_TLT_INIT
-        -DFLECSI_ENABLE_SPECIALIZATION_SPMD_INIT
-        -DCINCH_OVERRIDE_DEFAULT_INITIALIZATION_DRIVER
-        -DFLECSI_8_8_MESH
-      POLICY ${UNIT_POLICY}
-      THREADS 2
-      NOCI
-    )
+          ../supplemental/coloring/add_colorings.cc
+          ${DRIVER_INITIALIZATION}
+          ${RUNTIME_DRIVER}
+        INPUTS
+          test/simple2d-8x8.msh
+          test/simple2d-16x16.msh
+        LIBRARIES
+          FleCSI
+          ${CINCH_RUNTIME_LIBRARIES}
+          ${COLORING_LIBRARIES}
+        DEFINES
+          -DFLECSI_ENABLE_SPECIALIZATION_TLT_INIT
+          -DFLECSI_ENABLE_SPECIALIZATION_SPMD_INIT
+          -DCINCH_OVERRIDE_DEFAULT_INITIALIZATION_DRIVER
+          -DFLECSI_8_8_MESH
+        POLICY ${UNIT_POLICY}
+        THREADS 2
+        NOCI
+        FOLDER
+          "Tests/Execution"
+      )
 
     if(FLECSI_RUNTIME_MODEL STREQUAL "mpi")
       cinch_add_unit(set_topology
@@ -517,7 +539,7 @@ cinch_add_unit(future_handle
           ${DRIVER_INITIALIZATION}
           ${RUNTIME_DRIVER}
         LIBRARIES
-            FleCSI
+          FleCSI
           ${CINCH_RUNTIME_LIBRARIES}
           ${COLORING_LIBRARIES}
         DEFINES
@@ -527,6 +549,8 @@ cinch_add_unit(future_handle
         POLICY ${UNIT_POLICY}
         THREADS 2
         NOCI
+        FOLDER
+          "Tests/Execution"
       )
 
       # cinch_add_unit(particles

--- a/flecsi/execution/CMakeLists.txt
+++ b/flecsi/execution/CMakeLists.txt
@@ -202,26 +202,27 @@ cinch_add_unit(simple_task
     "Tests/Execution"
   )
 
-if(NOT FLECSI_RUNTIME_MODEL STREQUAL "hpx")
 #
 # Test basic task to test future_handle
 #
-  cinch_add_unit(future_handle
-    SOURCES
-      test/future_handle.cc
-      ${DRIVER_INITIALIZATION}
-      ${RUNTIME_DRIVER}
-    DEFINES
-      -DFLECSI_ENABLE_SPECIALIZATION_TLT_INIT
-      -DCINCH_OVERRIDE_DEFAULT_INITIALIZATION_DRIVER
-    POLICY
-      ${UNIT_POLICY}
-    LIBRARIES
-      FleCSI
-      ${CINCH_RUNTIME_LIBRARIES}
-    THREADS 2
-    NOCI
-    )
+cinch_add_unit(future_handle
+  SOURCES
+    test/future_handle.cc
+    ${DRIVER_INITIALIZATION}
+    ${RUNTIME_DRIVER}
+  DEFINES
+    -DFLECSI_ENABLE_SPECIALIZATION_TLT_INIT
+    -DCINCH_OVERRIDE_DEFAULT_INITIALIZATION_DRIVER
+  POLICY
+    ${UNIT_POLICY}
+  LIBRARIES
+    FleCSI
+    ${CINCH_RUNTIME_LIBRARIES}
+  THREADS 2
+  NOCI
+  FOLDER
+    "Tests/Execution"
+  )
 
   if(ENABLE_PARMETIS)
 
@@ -244,8 +245,11 @@ if(NOT FLECSI_RUNTIME_MODEL STREQUAL "hpx")
         -DCINCH_OVERRIDE_DEFAULT_INITIALIZATION_DRIVER
         -DFLECSI_8_8_MESH
       POLICY ${UNIT_POLICY}
+      FOLDER
+        "Tests/Execution"
     )
 
+  if(NOT FLECSI_RUNTIME_MODEL STREQUAL "hpx")
     cinch_add_devel_target(devel_handle
       SOURCES
         test/devel_handle.cc
@@ -544,6 +548,7 @@ if(NOT FLECSI_RUNTIME_MODEL STREQUAL "hpx")
       # )
     endif() # mpi
 
+    endif()# not hpx
   endif() # (ENABLE_PARMETIS)
 
   if(FLECSI_RUNTIME_MODEL STREQUAL "legion")
@@ -652,4 +657,3 @@ if(NOT FLECSI_RUNTIME_MODEL STREQUAL "hpx")
 
   endif() # legion
 
-endif()# not hpx

--- a/flecsi/execution/hpx/runtime_driver.cc
+++ b/flecsi/execution/hpx/runtime_driver.cc
@@ -9,6 +9,10 @@
 //----------------------------------------------------------------------------//
 
 #include <flecsi/execution/hpx/runtime_driver.h>
+#include <flecsi/execution/context.h>
+#include <flecsi/data/data.h>
+
+clog_register_tag(runtime_driver);
 
 namespace flecsi {
 namespace execution {
@@ -17,12 +21,161 @@ namespace execution {
 // Implementation of FleCSI runtime driver task.
 //----------------------------------------------------------------------------//
 
-int hpx_runtime_driver(int argc, char ** argv) {
+void
+remap_shared_entities()
+{
+  // TODO: Is this superseded by index_map/reverse_index_map?
+  auto& flecsi_context = context_t::instance();
+  const int my_color = static_cast<int>(flecsi_context.color());
+
+  for (auto& coloring_info_pair : flecsi_context.coloring_info_map()) {
+    auto index_space = coloring_info_pair.first;
+    auto &coloring_info = coloring_info_pair.second;
+
+    auto &my_coloring_info = flecsi_context.coloring_info(index_space).at(
+      my_color);
+    auto &index_coloring = flecsi_context.coloring(index_space);
+
+    std::set<flecsi::coloring::entity_info_t> new_shared;
+
+//    for (auto& shared : index_coloring.shared) {
+//      clog_rank(warn, 0) << "myrank: " << my_color
+//                         << " shared id: " << shared.id
+//                         << ", rank: " << shared.rank
+//                         << ", offset: " << shared.offset
+//                         << ", index: " << index << std::endl;
+//     }
+
+    // FIXME: does this cause deadlock?
+    size_t index = 0;
+    for (auto& shared : index_coloring.shared) {
+      for (auto peer : shared.shared) {
+        MPI_Send(
+            &index, 1, MPI_UNSIGNED_LONG_LONG, static_cast<int>(peer), 77,
+            MPI_COMM_WORLD);
+      }
+      new_shared.insert(
+        flecsi::coloring::entity_info_t(shared.id, shared.rank, index, shared.shared));
+      index++;
+    }
+    context_t::instance().coloring(index_space).shared.swap(new_shared);
+
+
+    MPI_Status status;
+    std::set<flecsi::coloring::entity_info_t> new_ghost;
+
+    for (auto ghost : index_coloring.ghost) {
+      MPI_Recv(&index, 1, MPI_UNSIGNED_LONG_LONG,
+               static_cast<int>(ghost.rank), 77, MPI_COMM_WORLD, &status);
+      new_ghost.insert(
+        flecsi::coloring::entity_info_t(ghost.id, ghost.rank, index, {}));
+    }
+//    for (auto ghost : index_coloring.ghost) {
+//      clog_rank(warn, 1) << "myrank: " << my_color
+//                         << " old ghost id: " << ghost.id
+//                         << ", rank: " << ghost.rank
+//                         << ", offset: " << ghost.offset
+//                         << std::endl;
+//    }
+//    for (auto ghost : new_ghost) {
+//      clog_rank(warn, 1) << "myrank: " << my_color
+//                         << " new ghost id: " << ghost.id
+//                         << ", rank: " << ghost.rank
+//                         << ", offset: " << ghost.offset
+//                         << std::endl;
+//    }
+    context_t::instance().coloring(index_space).ghost.swap(new_ghost);
+  }
+}
+
+int hpx_runtime_driver(int argc, char ** argv)
+{
+  {
+  clog_tag_guard(runtime_driver);
+  clog(info) << "In HPX runtime driver" << std::endl;
+  }
+
+  //--------------------------------------------------------------------------//
+  // Invoke callbacks for entries in the client registry.
+  //
+  // NOTE: This needs to be called before the field registry below because
+  //       The client callbacks register field callbacks with the field
+  //       registry.
+  //--------------------------------------------------------------------------//
+
+  auto & client_registry =
+    flecsi::data::storage_t::instance().client_registry();
+
+  for(auto & c: client_registry) {
+    for(auto & d: c.second) {
+      d.second.second(d.second.first);
+    } // for
+  } // for
+
+  //--------------------------------------------------------------------------//
+  // Invoke callbacks for entries in the field registry.
+  //--------------------------------------------------------------------------//
+
+  auto & field_registry =
+    flecsi::data::storage_t::instance().field_registry();
+
+  for(auto & c: field_registry) {
+    for(auto & f: c.second) {
+      f.second.second(f.first, f.second.first);
+    } // for
+  } // for
+
+  auto& flecsi_context = context_t::instance();
+  for (auto fi : flecsi_context.registered_fields()) {
+    flecsi_context.put_field_info(fi);
+  }
 
 #if defined FLECSI_ENABLE_SPECIALIZATION_TLT_INIT
+  {
+    clog_tag_guard(runtime_driver);
+    clog(info) << "Executing specialization tlt task" << std::endl;
+  }
+
   // Execute the specialization driver.
   specialization_tlt_init(argc, argv);
 #endif // FLECSI_ENABLE_SPECIALIZATION_TLT_INIT
+
+  remap_shared_entities();
+
+  // Setup maps from mesh to compacted (local) index space and vice versa
+  //
+  // This depends on the ordering of the BLIS data structure setup.
+  // Currently, this is Exclusive - Shared - Ghost.
+
+  for(auto is: flecsi_context.coloring_map()) {
+    std::map<size_t, size_t> _map;
+    std::size_t counter(0);
+
+    for(auto index: is.second.exclusive) {
+      _map[counter++] = index.id;
+    } // for
+
+    for(auto index: is.second.shared) {
+      _map[counter++] = index.id;
+    } // for
+
+    for(auto index: is.second.ghost) {
+      _map[counter++] = index.id;
+    } // for
+
+    flecsi_context.add_index_map(is.first, _map);
+  } // for
+
+  // Add additional setup.
+  context_t & context_ = context_t::instance();
+  context_.advance_state();
+
+  // Call the specialization color initialization function.
+#if defined(FLECSI_ENABLE_SPECIALIZATION_SPMD_INIT)
+  specialization_spmd_init(argc, argv);
+#endif // FLECSI_ENABLE_SPECIALIZATION_SPMD_INIT
+
+  context_.advance_state();
 
   // Execute the user driver.
   driver(argc, argv);

--- a/flecsi/execution/hpx/runtime_driver.h
+++ b/flecsi/execution/hpx/runtime_driver.h
@@ -22,7 +22,13 @@ void driver(int argc, char ** argv);
 //! \brief The specialization driver function to be defined by the user.
 //! \param[in] argc  The number of arguments in argv.
 //! \param[in] argv  The list arguments passed to the driver.
+#if defined(FLECSI_ENABLE_SPECIALIZATION_TLT_INIT)
 void specialization_tlt_init(int argc, char ** argv);
+#endif
+
+#if defined(FLECSI_ENABLE_SPECIALIZATION_SPMD_INIT)
+void specialization_spmd_init(int argc, char **argv);
+#endif // FLECSI_ENABLE_SPECIALIZATION_SPMD_INIT
 
 //! \brief The top-level serial runtime driver.
 //! \param[in] argc  The number of arguments in argv.

--- a/flecsi/execution/mpi/context_policy.cc
+++ b/flecsi/execution/mpi/context_policy.cc
@@ -23,20 +23,16 @@ namespace execution {
 // Implementation of mpi_context_policy_t::initialize.
 //----------------------------------------------------------------------------//
 
-int
-mpi_context_policy_t::initialize(
-  int argc,
-  char ** argv
-)
+void
+mpi_context_policy_t::start_mpi_runtime(
+    void (*driver)(int, char **), int argc, char ** argv)
 {
   MPI_Comm_rank(MPI_COMM_WORLD, &color_);
   MPI_Comm_size(MPI_COMM_WORLD, &colors_);
 
-  runtime_driver(argc, argv);
-
-  return 0;
+  (*driver)(argc, argv);
 } // mpi_context_policy_t::initialize
 
-} // namespace execution 
+} // namespace execution
 } // namespace flecsi
 

--- a/flecsi/execution/mpi/context_policy.h
+++ b/flecsi/execution/mpi/context_policy.h
@@ -40,6 +40,7 @@
 #include <flecsi/coloring/coloring_types.h>
 #include <flecsi/coloring/index_coloring.h>
 #include <flecsi/data/common/data_types.h>
+#include <flecsi/utils/export_definitions.h>
 
 namespace flecsi {
 namespace execution {
@@ -111,19 +112,31 @@ struct mpi_context_policy_t
   /*!
    FleCSI context initialization. This method initializes the FleCSI
    runtime using MPI.
-  
+
    @param argc The command-line argument count passed from main.
    @param argv The command-line argument values passed from main.
-  
+
    @return An integer value with a non-zero error code upon failure,
            zero otherwise.
    */
 
-  int
+private:
+  // Start the MPI runtime
+  FLECSI_EXPORT void
+  start_mpi_runtime(void (*driver)(int, char **), int argc, char ** argv);
+
+public:
+  // it is important for this to be inlined as otherwise we see unresolved
+  // external linker errors when using MSVC
+  inline int
   initialize(
     int argc,
     char ** argv
-  );
+  )
+  {
+    start_mpi_runtime(&runtime_driver, argc, argv);
+    return 0;
+  } // mpi_context_policy_t::initialize
 
   /*!
     Return the color for which the context was initialized.
@@ -135,7 +148,7 @@ struct mpi_context_policy_t
   {
     return color_;
   } // color
-  
+
   /*!
     Return the number of colors.
    */
@@ -164,7 +177,7 @@ struct mpi_context_policy_t
 
   /*!
    Register a task with the runtime.
-  
+
    @param key       The task hash key.
    @param name      The task name string.
    @param call_back The registration call back function.
@@ -556,7 +569,7 @@ struct mpi_context_policy_t
    Register new sparse field data, i.e. allocate a new buffer for the
    specified field ID. Sparse data consists of a buffer of offsets
    (start + length) and entry id / value pairs and associated metadata about
-   this field. 
+   this field.
    */
   void register_sparse_field_data(
     field_id_t fid,
@@ -596,7 +609,7 @@ struct mpi_context_policy_t
 
   /*!
    Set max_reduction
-  
+
    @param double max_reduction
    */
 
@@ -608,7 +621,7 @@ struct mpi_context_policy_t
 
   /*!
    Perform reduction for the maximum value type <double>
-  
+
    @param
    */
 
@@ -639,7 +652,7 @@ struct mpi_context_policy_t
 
   /*!
    Set min_reduction
-  
+
    @param double min_reduction
    */
 
@@ -651,7 +664,7 @@ struct mpi_context_policy_t
 
   /*!
    Perform reduction for the minimum value type <double>
-  
+
    @param
    */
 

--- a/flecsi/execution/mpi/runtime_driver.cc
+++ b/flecsi/execution/mpi/runtime_driver.cc
@@ -33,7 +33,7 @@ remap_shared_entities()
 {
   // TODO: Is this superseded by index_map/reverse_index_map?
   auto& flecsi_context = context_t::instance();
-  const int my_color = flecsi_context.color();
+  const int my_color = static_cast<int>(flecsi_context.color());
 
   for (auto& coloring_info_pair : flecsi_context.coloring_info_map()) {
     auto index_space = coloring_info_pair.first;
@@ -57,7 +57,9 @@ remap_shared_entities()
     size_t index = 0;
     for (auto& shared : index_coloring.shared) {
       for (auto peer : shared.shared) {
-        MPI_Send(&index, 1, MPI_UNSIGNED_LONG_LONG, peer, 77, MPI_COMM_WORLD);
+        MPI_Send(
+            &index, 1, MPI_UNSIGNED_LONG_LONG, static_cast<int>(peer), 77,
+            MPI_COMM_WORLD);
       }
       new_shared.insert(
         flecsi::coloring::entity_info_t(shared.id, shared.rank, index, shared.shared));
@@ -71,7 +73,7 @@ remap_shared_entities()
 
     for (auto ghost : index_coloring.ghost) {
       MPI_Recv(&index, 1, MPI_UNSIGNED_LONG_LONG,
-               ghost.rank, 77, MPI_COMM_WORLD, &status);
+               static_cast<int>(ghost.rank), 77, MPI_COMM_WORLD, &status);
       new_ghost.insert(
         flecsi::coloring::entity_info_t(ghost.id, ghost.rank, index, {}));
     }

--- a/flecsi/execution/test/data_handle_task.cc
+++ b/flecsi/execution/test/data_handle_task.cc
@@ -18,6 +18,7 @@
 #include <flecsi/supplemental/coloring/add_colorings.h>
 #include <flecsi/supplemental/mesh/empty_mesh_2d.h>
 #include <flecsi/data/dense_accessor.h>
+#include <flecsi/data/common/privilege.h>
 
 using namespace flecsi;
 using namespace supplemental;
@@ -140,7 +141,7 @@ void specialization_tlt_init(int argc, char ** argv) {
   clog(info) << "In specialization top-level-task init" << std::endl;
 
   auto & context = execution::context_t::instance();
- 
+
   ASSERT_EQ(context.execution_state(),
     static_cast<size_t>(SPECIALIZATION_TLT_INIT));
 
@@ -205,7 +206,7 @@ void driver(int argc, char ** argv) {
 //----------------------------------------------------------------------------//
 
 TEST(data_handle, testname) {
-  
+
 } // TEST
 
 } // namespace execution

--- a/flecsi/execution/test/devel_handle.cc
+++ b/flecsi/execution/test/devel_handle.cc
@@ -9,6 +9,8 @@
 #include <flecsi/execution/execution.h>
 #include <flecsi/supplemental/coloring/add_colorings.h>
 #include <flecsi/supplemental/mesh/test_mesh_2d.h>
+#include <flecsi/data/data.h>
+#include <flecsi/data/data_client_handle.h>
 #include <flecsi/data/dense_accessor.h>
 
 clog_register_tag(devel_handle);

--- a/flecsi/execution/test/future_handle.cc
+++ b/flecsi/execution/test/future_handle.cc
@@ -21,13 +21,13 @@
 //----------------------------------------------------------------------------//
 
 template<typename T>
-using handle_t = flecsi::execution::flecsi_future<T, 
+using future_handle_t = flecsi::execution::flecsi_future<T,
     flecsi::execution::launch_type_t::single>;
 
-void future_dump(handle_t<double> x)
+void future_dump(future_handle_t<double> x)
 {
-  double tmp = x;
-  std::cout << " future = "<< x << std::endl;
+  double tmp = x.get();
+  std::cout << " future = "<< x.get() << std::endl;
 }
 
 flecsi_register_task(future_dump, , loc, single);
@@ -40,10 +40,10 @@ double writer(double a)
 
 flecsi_register_task(writer, ,loc, single);
 
-void reader(handle_t<double> x, handle_t<double> y)
+void reader(future_handle_t<double> x, future_handle_t<double> y)
 {
-  ASSERT_EQ(x, static_cast<double>(3.14));
-  ASSERT_EQ(x, y);
+  ASSERT_EQ(x.get(), static_cast<double>(3.14));
+  ASSERT_EQ(x.get(), y.get());
 }
 
 flecsi_register_task(reader, , loc, single);

--- a/flecsi/execution/test/index_subspaces.cc
+++ b/flecsi/execution/test/index_subspaces.cc
@@ -8,6 +8,9 @@
 #include <flecsi/execution/context.h>
 #include <flecsi/execution/execution.h>
 #include <flecsi/supplemental/coloring/add_colorings.h>
+#include <flecsi/data/data.h>
+#include <flecsi/data/data_client_handle.h>
+#include <flecsi/data/dense_accessor.h>
 
 #define FLECSI_TEST_MESH_INDEX_SUBSPACES 1
 #include <flecsi/supplemental/mesh/test_mesh_2d.h>

--- a/flecsi/supplemental/coloring/coloring_functions.h
+++ b/flecsi/supplemental/coloring/coloring_functions.h
@@ -32,7 +32,7 @@ namespace execution {
 //! @tparam
 //----------------------------------------------------------------------------//
 
-template < 
+template <
   size_t DIMENSION,
   size_t ENTITY_DIM,
   typename CLOSURE_SET,
@@ -54,7 +54,7 @@ void color_entity(
 {
   // some compile time constants
   constexpr auto cell_dim = DIMENSION;
-  
+
   // some type aliases
   using entity_info_t = flecsi::coloring::entity_info_t;
 
@@ -63,7 +63,7 @@ void color_entity(
   auto rank = communicator->rank();
 
   // Form the entity closure
-  auto entity_closure = 
+  auto entity_closure =
     flecsi::topology::entity_closure<cell_dim, ENTITY_DIM>(md, closure);
 
   // Assign entity ownership
@@ -75,7 +75,7 @@ void color_entity(
     for(auto i: entity_closure) {
 
       // Get the set of cells that reference this entity.
-      auto referencers = 
+      auto referencers =
         flecsi::topology::entity_referencers<cell_dim, ENTITY_DIM>(md, i);
 
       {
@@ -83,7 +83,7 @@ void color_entity(
         clog_container_one(info, i << " referencers", referencers, clog::space);
       } // guard
 
-      size_t min_rank(std::numeric_limits<size_t>::max());
+      size_t min_rank((std::numeric_limits<size_t>::max)());
       std::set<size_t> shared_entities;
 
       // Iterate the direct referencers to assign entity ownership.
@@ -93,7 +93,7 @@ void color_entity(
         // off-color. If it is, compare it's rank for
         // the ownership logic below.
         if(remote_info_map.find(c) != remote_info_map.end()) {
-          min_rank = std::min(min_rank, remote_info_map.at(c).rank);
+          min_rank = (std::min)(min_rank, remote_info_map.at(c).rank);
           shared_entities.insert(remote_info_map.at(c).rank);
         }
         else {
@@ -101,12 +101,12 @@ void color_entity(
           // it is a local cell.
 
           // Add our rank to compare for ownership.
-          min_rank = std::min(min_rank, size_t(rank));
+          min_rank = (std::min)(min_rank, size_t(rank));
 
           // If the local cell is shared, we need to add all of
           // the ranks that reference it.
-          if(shared_cells_map.find(c) != shared_cells_map.end()) 
-            shared_entities.insert( 
+          if(shared_cells_map.find(c) != shared_cells_map.end())
+            shared_entities.insert(
               shared_cells_map.at(c).shared.begin(),
               shared_cells_map.at(c).shared.end()
             );
@@ -115,8 +115,8 @@ void color_entity(
         // Iterate through the closure intersection map to see if the
         // indirect reference is part of another rank's closure, i.e.,
         // that it is an indirect dependency.
-        for(auto ci: closure_intersection_map) 
-          if(ci.second.find(c) != ci.second.end()) 
+        for(auto ci: closure_intersection_map)
+          if(ci.second.find(c) != ci.second.end())
             shared_entities.insert(ci.first);
       } // for
 
@@ -142,11 +142,11 @@ void color_entity(
       entities.shared.insert(i);
       // Collect all colors with whom we require communication
       // to send shared information.
-      entity_color_info.shared_users = 
+      entity_color_info.shared_users =
         flecsi::utils::set_union(entity_color_info.shared_users, i.shared);
     }
     // otherwise, its exclusive
-    else 
+    else
       entities.exclusive.insert(i);
   } // for
 
@@ -171,9 +171,9 @@ void color_entity(
   {
     clog_tag_guard(coloring_functions);
     clog_container_one(
-      info, 
-      "exclusive entities("<<ENTITY_DIM<<")", 
-      entities.exclusive, 
+      info,
+      "exclusive entities("<<ENTITY_DIM<<")",
+      entities.exclusive,
       clog::newline
     );
     clog_container_one(
@@ -184,7 +184,7 @@ void color_entity(
     );
   } // guard
 
-  
+
   entity_color_info.exclusive = entities.exclusive.size();
   entity_color_info.shared = entities.shared.size();
   entity_color_info.ghost = entities.ghost.size();

--- a/flecsi/utils/CMakeLists.txt
+++ b/flecsi/utils/CMakeLists.txt
@@ -117,6 +117,7 @@ cinch_add_devel_target(clog
   SOURCES
     test/clog.cc
   POLICY ${UNIT_POLICY}
+  FOLDER "Tests/Util"
 )
 endif()
 
@@ -201,6 +202,7 @@ cinch_add_unit(set_utils
 
 cinch_add_unit(simple_id
   SOURCES test/simple_id.cc
+  FOLDER "Tests/Util"
 )
 
 cinch_add_unit(static_verify
@@ -243,6 +245,7 @@ cinch_add_unit(tuple_function
 cinch_add_unit(dag
   SOURCES test/dag.cc
   LIBRARIES ${FLECSI_LIBRARY_DEPENDENCIES}
+  FOLDER "Tests/Util"
 )
 
 set(index_space_blessed_input test/index_space.blessed.gnug)

--- a/flecsi/utils/hash.h
+++ b/flecsi/utils/hash.h
@@ -84,7 +84,7 @@ template<size_t NAMESPACE, size_t NAME>
 inline constexpr size_t
 field_hash(size_t version) {
   return ((NAMESPACE ^ NAME) << field_hash_version_bits | version) &
-         ~(1ul << 63);
+         ~(1ull << 63);
 } // field_hash
 
 inline size_t

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -9,6 +9,8 @@
 
 add_executable(flecsi-mg mesh-gen/main.cc)
 
+set_target_properties(flecsi-mg PROPERTIES FOLDER "Tools")
+
 #------------------------------------------------------------------------------#
 # Collect information for FleCSIT
 #------------------------------------------------------------------------------#


### PR DESCRIPTION
This allows building FLeCSI using the MPI backend using MSVC.

This also relies on #412 being merged first (this actually includes all of it).