### PR TITLE
Added flag that enables undefined symbols in shared libs for OSX.

### DIFF
--- a/config/project.cmake
+++ b/config/project.cmake
@@ -420,6 +420,16 @@ install(
 )
 
 #------------------------------------------------------------------------------#
+# Add Apple-specific flag for shared library
+#------------------------------------------------------------------------------#
+
+if(APPLE)
+  message(STATUS "Adding Apple-specific shared lib flag")
+  set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS
+    "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -undefined dynamic_lookup")
+endif()
+
+#------------------------------------------------------------------------------#
 # Add library targets
 #------------------------------------------------------------------------------#
 


### PR DESCRIPTION
# Overview 
Fix problem with shared libs on OSX

# Details
Add the flag "-undefine dynamic_lookup" to the linker when creating shared libs. This tells the linker to chill if a symbol is undefined when the library is created; it will be supplied later. That is the default behavior on linux, but FreeBSD thinks, er, different. This enables FleCSI's framework-like behavior, where FleCSI functions call functions defined by its users.