### PR TITLE
Move connectivity_t and related types out of mesh_types.h

### DIFF
--- a/flecsi/topology/CMakeLists.txt
+++ b/flecsi/topology/CMakeLists.txt
@@ -22,6 +22,7 @@ set(topology_HEADERS
   color_topology.h
   common/array_buffer.h
   common/entity_storage.h
+  connectivity.h
   entity_storage.h
   index_space.h
   mesh_definition.h

--- a/flecsi/topology/connectivity.h
+++ b/flecsi/topology/connectivity.h
@@ -1,0 +1,321 @@
+/*
+    @@@@@@@@  @@           @@@@@@   @@@@@@@@ @@
+   /@@/////  /@@          @@////@@ @@////// /@@
+   /@@       /@@  @@@@@  @@    // /@@       /@@
+   /@@@@@@@  /@@ @@///@@/@@       /@@@@@@@@@/@@
+   /@@////   /@@/@@@@@@@/@@       ////////@@/@@
+   /@@       /@@/@@//// //@@    @@       /@@/@@
+   /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
+   //       ///  //////   //////  ////////  //
+
+   Copyright (c) 2016, Los Alamos National Security, LLC
+   All rights reserved.
+                                                                              */
+#pragma once
+
+/*! @file */
+
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+
+#include <flecsi/topology/entity_storage.h>
+#include <flecsi/topology/index_space.h>
+#include <flecsi/topology/types.h>
+#include <flecsi/utils/array_ref.h>
+#include <flecsi/utils/reorder.h>
+
+namespace flecsi {
+namespace topology {
+
+/*----------------------------------------------------------------------------*
+ * class connectivity_t
+ *----------------------------------------------------------------------------*/
+
+//-----------------------------------------------------------------//
+//! \class connectivity_t connectivity.h
+//! \brief connectivity_t provides basic connectivity information in a
+//! compressed storage format.
+//-----------------------------------------------------------------//
+class connectivity_t {
+public:
+  using id_t = utils::id_t;
+  using offset_t = utils::offset_t;
+
+  connectivity_t(const connectivity_t &) = delete;
+
+  connectivity_t & operator=(const connectivity_t &) = delete;
+
+  // allow move operations
+  connectivity_t(connectivity_t &&) = default;
+  connectivity_t & operator=(connectivity_t &&) = default;
+
+  //! Constructor.
+  connectivity_t() : index_space_(false) {}
+
+  auto entity_storage() {
+    return index_space_.storage();
+  }
+
+  template<class STORAGE_TYPE>
+  void set_entity_storage(STORAGE_TYPE s) {
+    index_space_.set_storage(s);
+  }
+
+  //-----------------------------------------------------------------//
+  //! Clear the storage arrays for this instance.
+  //-----------------------------------------------------------------//
+  void clear() {
+    index_space_.clear();
+    offsets_.clear();
+  } // clear
+
+  //-----------------------------------------------------------------//
+  //! Initialize the connectivity information from a given connectivity
+  //! vector.
+  //!
+  //! \param cv The connectivity information.
+  //-----------------------------------------------------------------//
+  void init(const connection_vector_t & cv) {
+
+    clear();
+
+    // populate the to id's and add from offsets for each connectivity group
+
+    size_t start = index_space_.begin_push_();
+
+    size_t n = cv.size();
+
+    for (size_t i = 0; i < n; ++i) {
+      const id_vector_t & iv = cv[i];
+
+      for (id_t id : iv) {
+        index_space_.batch_push_(id);
+      } // for
+
+      offsets_.add_count(static_cast<std::uint32_t>(iv.size()));
+    } // for
+
+    index_space_.end_push_(start);
+  } // init
+
+  //-----------------------------------------------------------------//
+  //! Resize a connection.
+  //!
+  //! \param num_conns Number of connections for each group
+  //-----------------------------------------------------------------//
+  void resize(index_vector_t & num_conns) {
+    clear();
+
+    size_t n = num_conns.size();
+
+    uint64_t size = 0;
+
+    for (size_t i = 0; i < n; ++i) {
+      uint32_t count = static_cast<std::uint32_t>(num_conns[i]);
+      offsets_.add_count(count);
+      size += count;
+    } // for
+
+    index_space_.resize_(size);
+    index_space_.fill_(id_t(0));
+  } // resize
+
+  //-----------------------------------------------------------------//
+  //! Push a single id into the current from group.
+  //-----------------------------------------------------------------//
+  void push(id_t id) {
+    index_space_.push_(id);
+  } // push
+
+  //-----------------------------------------------------------------//
+  //! Debugging method. Dump the raw vectors of the connection.
+  //-----------------------------------------------------------------//
+  std::ostream & dump(std::ostream & stream) {
+    for (size_t i = 0; i < offsets_.size(); ++i) {
+      offset_t oi = offsets_[i];
+      for (size_t j = 0; j < oi.count(); ++j) {
+        stream << index_space_(oi.start() + j).entity() << std::endl;
+      }
+      stream << std::endl;
+    }
+
+    stream << "=== indices" << std::endl;
+    for (id_t id : index_space_.ids()) {
+      stream << id.entity() << std::endl;
+    } // for
+
+    stream << "=== offsets" << std::endl;
+    for (size_t i = 0; i < offsets_.size(); ++i) {
+      offset_t oi = offsets_[i];
+      stream << oi.start() << " : " << oi.count() << std::endl;
+    } // for
+    return stream;
+  } // dump
+
+  void dump() {
+    dump(std::cout);
+  } // dump
+
+  //-----------------------------------------------------------------//
+  //! Get the to id's vector.
+  //-----------------------------------------------------------------//
+  const auto & get_entities() const {
+    return index_space_.id_storage();
+  }
+  //-----------------------------------------------------------------//
+  //! Get the entities of the specified from index.
+  //-----------------------------------------------------------------//
+  id_t * get_entities(size_t index) {
+    assert(index < offsets_.size());
+    return index_space_.id_array() + offsets_[index].start();
+  }
+
+  //-----------------------------------------------------------------//
+  //! Get the entities of the specified from index and return the count.
+  //-----------------------------------------------------------------//
+  id_t * get_entities(size_t index, size_t & count) {
+    assert(index < offsets_.size());
+    offset_t o = offsets_[index];
+    count = o.count();
+    return index_space_.id_array() + o.start();
+  }
+
+  //-----------------------------------------------------------------//
+  //! Get the entities of the specified from index and return the count.
+  //-----------------------------------------------------------------//
+  auto get_entity_vec(size_t index) const {
+    assert(index < offsets_.size());
+    offset_t o = offsets_[index];
+    return utils::make_array_ref(
+        index_space_.id_array() + o.start(), o.count());
+  }
+
+  //-----------------------------------------------------------------//
+  //! Get the entities of the specified from index and return the count.
+  //-----------------------------------------------------------------//
+  void reverse_entities(size_t index) {
+    assert(index < offsets_.size());
+    offset_t o = offsets_[index];
+    std::reverse(
+        index_space_.index_begin_() + o.start(),
+        index_space_.index_begin_() + o.end());
+  }
+
+  //-----------------------------------------------------------------//
+  //! Get the entities of the specified from index and return the count.
+  //-----------------------------------------------------------------//
+  template<class U>
+  void reorder_entities(size_t index, U && order) {
+    assert(index < offsets_.size());
+    offset_t o = offsets_[index];
+    assert(order.size() == o.count());
+    utils::reorder(
+        order.begin(), order.end(), index_space_.id_array() + o.start());
+  }
+
+  //-----------------------------------------------------------------//
+  //! True if the connectivity is empty (hasn't been populated).
+  //-----------------------------------------------------------------//
+  bool empty() const {
+    return index_space_.empty();
+  }
+
+  //-----------------------------------------------------------------//
+  //! Set a single connection.
+  //-----------------------------------------------------------------//
+  void set(size_t from_local_id, id_t to_id, size_t pos) {
+    index_space_(offsets_[from_local_id].start() + pos) = to_id;
+  }
+
+  //-----------------------------------------------------------------//
+  //! Return the number of from entities.
+  //-----------------------------------------------------------------//
+  size_t from_size() const {
+    return offsets_.size();
+  }
+
+  //-----------------------------------------------------------------//
+  //! Return the number of to entities.
+  //-----------------------------------------------------------------//
+  size_t to_size() const {
+    return index_space_.size();
+  }
+
+  //-----------------------------------------------------------------//
+  //! Set/init the connectivity use by compute topology methods like transpose.
+  //-----------------------------------------------------------------//
+  template<size_t DOM, size_t NUM_DOMAINS>
+  void set(entity_vector_t<NUM_DOMAINS> & ev, connection_vector_t & conns) {
+    clear();
+
+    size_t n = conns.size();
+
+    size_t size = 0;
+
+    for (size_t i = 0; i < n; i++) {
+      uint32_t count = conns[i].size();
+      offsets_.add_count(count);
+      size += count;
+    }
+
+    index_space_.begin_push_(size);
+
+    for (size_t i = 0; i < n; ++i) {
+      const id_vector_t & conn = conns[i];
+      uint64_t m = conn.size();
+
+      for (size_t j = 0; j < m; ++j) {
+        index_space_.batch_push_(ev[conn[j]]->template global_id<DOM>());
+      }
+    }
+  }
+
+  const auto & to_id_storage() const {
+    return index_space_.id_storage();
+  }
+
+  auto & to_id_storage() {
+    return index_space_.id_storage_();
+  }
+
+  auto & get_index_space() {
+    return index_space_;
+  }
+
+  auto & get_index_space() const {
+    return index_space_;
+  }
+
+  auto range(size_t i) const {
+    return offsets_.range(i);
+  }
+
+  auto & offsets() {
+    return offsets_;
+  }
+
+  const auto & offsets() const {
+    return offsets_;
+  }
+
+  void add_count(uint32_t count) {
+    offsets_.add_count(count);
+  }
+
+  //-----------------------------------------------------------------//
+  //! End a from entity group by setting the end offset in the
+  //! from connection vector.
+  //-----------------------------------------------------------------//
+  void end_from() {
+    offsets_.add_end(index_space_.size());
+  } // end_from
+
+  index_space__<entity_base_ *, false, true, false, void, entity_storage_t>
+      index_space_;
+
+  offset_storage_t offsets_;
+}; // class connectivity_t
+
+} // namespace topology
+} // namespace flecsi

--- a/flecsi/topology/mesh_types.h
+++ b/flecsi/topology/mesh_types.h
@@ -19,103 +19,29 @@
 #include <cassert>
 #include <cstdint>
 #include <iostream>
-#include <unordered_map>
 #include <vector>
 
 #include <flecsi/data/data_client.h>
 #include <flecsi/execution/context.h>
-#include <flecsi/topology/entity_storage.h>
-#include <flecsi/topology/index_space.h>
+#include <flecsi/topology/connectivity.h>
 #include <flecsi/topology/mesh_utils.h>
 #include <flecsi/topology/partition.h>
 #include <flecsi/topology/types.h>
-#include <flecsi/utils/array_ref.h>
-#include <flecsi/utils/reorder.h>
 
 namespace flecsi {
 namespace topology {
 
 /*----------------------------------------------------------------------------*
- * class mesh_entity_base__
+ * class entity_base__
  *----------------------------------------------------------------------------*/
 
 template<class>
 class mesh_topology_base__;
 
-//-----------------------------------------------------------------//
-//! \class mesh_entity_base__ mesh_types.h
-//! \brief mesh_entity_base__ defines a base class that stores the raw info that
-//! the mesh topology needs, i.e: id and rank data
-//!
-//! \tparam N The number of mesh domains.
-//-----------------------------------------------------------------//
-
-class mesh_entity_base_ {
-public:
-  using id_t = flecsi::utils::id_t;
-};
-
+// Aliases for backward compatibility
+using mesh_entity_base_ = entity_base_;
 template<size_t NUM_DOMAINS>
-class mesh_entity_base__ : public mesh_entity_base_ {
-public:
-  ~mesh_entity_base__() {}
-
-  //-----------------------------------------------------------------//
-  //! Return the id of this entity.
-  //!
-  //! \return The id of the entity.
-  //-----------------------------------------------------------------//
-  template<size_t DOM = 0>
-  id_t global_id() const {
-    return ids_[DOM];
-  } // id
-
-  id_t global_id(size_t domain) const {
-    return ids_[domain];
-  } // id
-
-  template<size_t DOM = 0>
-  size_t id() const {
-    return ids_[DOM].entity();
-  } // id
-
-  size_t id(size_t domain) const {
-    return ids_[domain].entity();
-  } // id
-
-  template<size_t DOM = 0>
-  uint16_t info() const {
-    return ids_[DOM] >> 48;
-  } // info
-
-  //-----------------------------------------------------------------//
-  //! Set the id of this entity.
-  //-----------------------------------------------------------------//
-  template<size_t DOM = 0>
-  void set_global_id(const id_t & id) {
-    ids_[DOM] = id;
-  } // id
-
-  /*!
-   */
-
-  static constexpr size_t get_dim_(size_t meshDim, size_t dim) {
-    return dim > meshDim ? meshDim : dim;
-  } // get_dim_
-
-  template<class MESH_TYPE>
-  friend class mesh_topology__;
-
-protected:
-  template<size_t DOM = 0>
-  void set_info(uint16_t info) {
-    ids_[DOM] = (uint64_t(info) << 48) | ids_[DOM];
-  } // set_info
-
-private:
-  std::array<id_t, NUM_DOMAINS> ids_;
-
-}; // class mesh_entity_base__
+using mesh_entity_base__ = entity_base__<NUM_DOMAINS>;
 
 /*----------------------------------------------------------------------------*
  * class mesh_entity__
@@ -131,7 +57,7 @@ private:
 //-----------------------------------------------------------------//
 
 template<size_t DIM, size_t NUM_DOMAINS>
-class mesh_entity__ : public mesh_entity_base__<NUM_DOMAINS> {
+class mesh_entity__ : public entity_base__<NUM_DOMAINS> {
 public:
   static constexpr size_t dimension = DIM;
 
@@ -142,14 +68,6 @@ public:
 // Redecalre the dimension.  This is redundant, and no longer needed in C++17.
 template<size_t DIM, size_t NUM_DOMAINS>
 constexpr size_t mesh_entity__<DIM, NUM_DOMAINS>::dimension;
-
-//-----------------------------------------------------------------//
-//! Define the vector type for storing entities.
-//!
-//! \tparam NUM_DOMAINS The number of domains.
-//-----------------------------------------------------------------//
-template<size_t NUM_DOMAINS>
-using entity_vector_t = std::vector<mesh_entity_base__<NUM_DOMAINS> *>;
 
 /*----------------------------------------------------------------------------*
  * class domain_entity_t
@@ -238,295 +156,6 @@ public:
 private:
   ENTITY_TYPE * entity_;
 };
-
-/*----------------------------------------------------------------------------*
- * class connectivity_t
- *----------------------------------------------------------------------------*/
-
-//-----------------------------------------------------------------//
-//! \class connectivity_t mesh_topology.h
-//! \brief connectivity_t provides basic connectivity information in a
-//! compressed storage format.
-//-----------------------------------------------------------------//
-class connectivity_t {
-public:
-  using id_t = utils::id_t;
-  using offset_t = utils::offset_t;
-
-  connectivity_t(const connectivity_t &) = delete;
-
-  connectivity_t & operator=(const connectivity_t &) = delete;
-
-  // allow move operations
-  connectivity_t(connectivity_t &&) = default;
-  connectivity_t & operator=(connectivity_t &&) = default;
-
-  //! Constructor.
-  connectivity_t() : index_space_(false) {}
-
-  auto entity_storage() {
-    return index_space_.storage();
-  }
-
-  template<class STORAGE_TYPE>
-  void set_entity_storage(STORAGE_TYPE s) {
-    index_space_.set_storage(s);
-  }
-
-  //-----------------------------------------------------------------//
-  //! Clear the storage arrays for this instance.
-  //-----------------------------------------------------------------//
-  void clear() {
-    index_space_.clear();
-    offsets_.clear();
-  } // clear
-
-  //-----------------------------------------------------------------//
-  //! Initialize the connectivity information from a given connectivity
-  //! vector.
-  //!
-  //! \param cv The connectivity information.
-  //-----------------------------------------------------------------//
-  void init(const connection_vector_t & cv) {
-
-    clear();
-
-    // populate the to id's and add from offsets for each connectivity group
-
-    size_t start = index_space_.begin_push_();
-
-    size_t n = cv.size();
-
-    for (size_t i = 0; i < n; ++i) {
-      const id_vector_t & iv = cv[i];
-
-      for (id_t id : iv) {
-        index_space_.batch_push_(id);
-      } // for
-
-      offsets_.add_count(static_cast<std::uint32_t>(iv.size()));
-    } // for
-
-    index_space_.end_push_(start);
-  } // init
-
-  //-----------------------------------------------------------------//
-  //! Resize a connection.
-  //!
-  //! \param num_conns Number of connections for each group
-  //-----------------------------------------------------------------//
-  void resize(index_vector_t & num_conns) {
-    clear();
-
-    size_t n = num_conns.size();
-
-    uint64_t size = 0;
-
-    for (size_t i = 0; i < n; ++i) {
-      uint32_t count = static_cast<std::uint32_t>(num_conns[i]);
-      offsets_.add_count(count);
-      size += count;
-    } // for
-
-    index_space_.resize_(size);
-    index_space_.fill_(id_t(0));
-  } // resize
-
-  //-----------------------------------------------------------------//
-  //! Push a single id into the current from group.
-  //-----------------------------------------------------------------//
-  void push(id_t id) {
-    index_space_.push_(id);
-  } // push
-
-  //-----------------------------------------------------------------//
-  //! Debugging method. Dump the raw vectors of the connection.
-  //-----------------------------------------------------------------//
-  std::ostream & dump(std::ostream & stream) {
-    for (size_t i = 0; i < offsets_.size(); ++i) {
-      offset_t oi = offsets_[i];
-      for (size_t j = 0; j < oi.count(); ++j) {
-        stream << index_space_(oi.start() + j).entity() << std::endl;
-      }
-      stream << std::endl;
-    }
-
-    stream << "=== indices" << std::endl;
-    for (id_t id : index_space_.ids()) {
-      stream << id.entity() << std::endl;
-    } // for
-
-    stream << "=== offsets" << std::endl;
-    for (size_t i = 0; i < offsets_.size(); ++i) {
-      offset_t oi = offsets_[i];
-      stream << oi.start() << " : " << oi.count() << std::endl;
-    } // for
-    return stream;
-  } // dump
-
-  void dump() {
-    dump(std::cout);
-  } // dump
-
-  //-----------------------------------------------------------------//
-  //! Get the to id's vector.
-  //-----------------------------------------------------------------//
-  const auto & get_entities() const {
-    return index_space_.id_storage();
-  }
-  //-----------------------------------------------------------------//
-  //! Get the entities of the specified from index.
-  //-----------------------------------------------------------------//
-  id_t * get_entities(size_t index) {
-    assert(index < offsets_.size());
-    return index_space_.id_array() + offsets_[index].start();
-  }
-
-  //-----------------------------------------------------------------//
-  //! Get the entities of the specified from index and return the count.
-  //-----------------------------------------------------------------//
-  id_t * get_entities(size_t index, size_t & count) {
-    assert(index < offsets_.size());
-    offset_t o = offsets_[index];
-    count = o.count();
-    return index_space_.id_array() + o.start();
-  }
-
-  //-----------------------------------------------------------------//
-  //! Get the entities of the specified from index and return the count.
-  //-----------------------------------------------------------------//
-  auto get_entity_vec(size_t index) const {
-    assert(index < offsets_.size());
-    offset_t o = offsets_[index];
-    return utils::make_array_ref(
-        index_space_.id_array() + o.start(), o.count());
-  }
-
-  //-----------------------------------------------------------------//
-  //! Get the entities of the specified from index and return the count.
-  //-----------------------------------------------------------------//
-  void reverse_entities(size_t index) {
-    assert(index < offsets_.size());
-    offset_t o = offsets_[index];
-    std::reverse(
-        index_space_.index_begin_() + o.start(),
-        index_space_.index_begin_() + o.end());
-  }
-
-  //-----------------------------------------------------------------//
-  //! Get the entities of the specified from index and return the count.
-  //-----------------------------------------------------------------//
-  template<class U>
-  void reorder_entities(size_t index, U && order) {
-    assert(index < offsets_.size());
-    offset_t o = offsets_[index];
-    assert(order.size() == o.count());
-    utils::reorder(
-        order.begin(), order.end(), index_space_.id_array() + o.start());
-  }
-
-  //-----------------------------------------------------------------//
-  //! True if the connectivity is empty (hasn't been populated).
-  //-----------------------------------------------------------------//
-  bool empty() const {
-    return index_space_.empty();
-  }
-
-  //-----------------------------------------------------------------//
-  //! Set a single connection.
-  //-----------------------------------------------------------------//
-  void set(size_t from_local_id, id_t to_id, size_t pos) {
-    index_space_(offsets_[from_local_id].start() + pos) = to_id;
-  }
-
-  //-----------------------------------------------------------------//
-  //! Return the number of from entities.
-  //-----------------------------------------------------------------//
-  size_t from_size() const {
-    return offsets_.size();
-  }
-
-  //-----------------------------------------------------------------//
-  //! Return the number of to entities.
-  //-----------------------------------------------------------------//
-  size_t to_size() const {
-    return index_space_.size();
-  }
-
-  //-----------------------------------------------------------------//
-  //! Set/init the connectivity use by compute topology methods like transpose.
-  //-----------------------------------------------------------------//
-  template<size_t DOM, size_t NUM_DOMAINS>
-  void set(entity_vector_t<NUM_DOMAINS> & ev, connection_vector_t & conns) {
-    clear();
-
-    size_t n = conns.size();
-
-    size_t size = 0;
-
-    for (size_t i = 0; i < n; i++) {
-      uint32_t count = conns[i].size();
-      offsets_.add_count(count);
-      size += count;
-    }
-
-    index_space_.begin_push_(size);
-
-    for (size_t i = 0; i < n; ++i) {
-      const id_vector_t & conn = conns[i];
-      uint64_t m = conn.size();
-
-      for (size_t j = 0; j < m; ++j) {
-        index_space_.batch_push_(ev[conn[j]]->template global_id<DOM>());
-      }
-    }
-  }
-
-  const auto & to_id_storage() const {
-    return index_space_.id_storage();
-  }
-
-  auto & to_id_storage() {
-    return index_space_.id_storage_();
-  }
-
-  auto & get_index_space() {
-    return index_space_;
-  }
-
-  auto & get_index_space() const {
-    return index_space_;
-  }
-
-  auto range(size_t i) const {
-    return offsets_.range(i);
-  }
-
-  auto & offsets() {
-    return offsets_;
-  }
-
-  const auto & offsets() const {
-    return offsets_;
-  }
-
-  void add_count(uint32_t count) {
-    offsets_.add_count(count);
-  }
-
-  //-----------------------------------------------------------------//
-  //! End a from entity group by setting the end offset in the
-  //! from connection vector.
-  //-----------------------------------------------------------------//
-  void end_from() {
-    offsets_.add_end(index_space_.size());
-  } // end_from
-
-  index_space__<mesh_entity_base_ *, false, true, false, void, entity_storage_t>
-      index_space_;
-
-  offset_storage_t offsets_;
-}; // class connectivity_t
 
 //-----------------------------------------------------------------//
 //! Holds the connectivities from domain M1 -> M2 for all topological
@@ -750,7 +379,7 @@ public:
   virtual void append_to_index_space_(
       size_t domain,
       size_t dimension,
-      std::vector<mesh_entity_base_ *> & ents,
+      std::vector<entity_base_ *> & ents,
       std::vector<id_t> & ids) = 0;
 
 protected:
@@ -773,7 +402,7 @@ unserialize_dimension_(
 
   using id_t = utils::id_t;
 
-  std::vector<mesh_entity_base_ *> ents;
+  std::vector<entity_base_ *> ents;
   std::vector<id_t> ids;
   ents.reserve(num_entities);
   ids.reserve(num_entities);

--- a/flecsi/topology/types.h
+++ b/flecsi/topology/types.h
@@ -15,6 +15,7 @@
 
 /*! @file */
 
+#include <array>
 #include <unordered_map>
 #include <vector>
 
@@ -73,6 +74,86 @@ using id_vector_map_t =
 
 // the second topology vector holds the offsets into to from dimension
 using index_vector_t = std::vector<size_t>;
+
+//-----------------------------------------------------------------//
+//! \class entity_base__ types.h
+//! \brief entity_base__ defines a base class that stores the raw info that
+//! a topology needs, i.e: id and rank data
+//!
+//! \tparam N The number of domains.
+//-----------------------------------------------------------------//
+
+class entity_base_ {
+public:
+  using id_t = flecsi::utils::id_t;
+};
+
+template<size_t NUM_DOMAINS>
+class entity_base__ : public entity_base_ {
+public:
+  ~entity_base__() {}
+
+  //-----------------------------------------------------------------//
+  //! Return the id of this entity.
+  //!
+  //! \return The id of the entity.
+  //-----------------------------------------------------------------//
+  template<size_t DOM = 0>
+  id_t global_id() const {
+    return ids_[DOM];
+  } // id
+
+  id_t global_id(size_t domain) const {
+    return ids_[domain];
+  } // id
+
+  template<size_t DOM = 0>
+  size_t id() const {
+    return ids_[DOM].entity();
+  } // id
+
+  size_t id(size_t domain) const {
+    return ids_[domain].entity();
+  } // id
+
+  template<size_t DOM = 0>
+  uint16_t info() const {
+    return ids_[DOM] >> 48;
+  } // info
+
+  //-----------------------------------------------------------------//
+  //! Set the id of this entity.
+  //-----------------------------------------------------------------//
+  template<size_t DOM = 0>
+  void set_global_id(const id_t & id) {
+    ids_[DOM] = id;
+  } // id
+
+  /*!
+   */
+
+  static constexpr size_t get_dim_(size_t meshDim, size_t dim) {
+    return dim > meshDim ? meshDim : dim;
+  } // get_dim_
+
+protected:
+  template<size_t DOM = 0>
+  void set_info(uint16_t info) {
+    ids_[DOM] = (uint64_t(info) << 48) | ids_[DOM];
+  } // set_info
+
+private:
+  std::array<id_t, NUM_DOMAINS> ids_;
+
+}; // class entity_base__
+
+//-----------------------------------------------------------------//
+//! Define the vector type for storing entities.
+//!
+//! \tparam NUM_DOMAINS The number of domains.
+//-----------------------------------------------------------------//
+template<size_t NUM_DOMAINS>
+using entity_vector_t = std::vector<entity_base__<NUM_DOMAINS> *>;
 
 } // namespace topology
 } // namespace flecsi


### PR DESCRIPTION
This PR is intended to allow connectivity_t to be used by non-mesh topologies, by doing the following:

- Rename `mesh_entity_base(_|__)` by removing the prefix `mesh_`.  Add aliases from the old names to the new, for backward compatibility.
- Move `entity_base(_|__)` and `entity_vector_t` from `mesh_types.h` to `types.h`.
- Move `connectivity_t` into a new file `connectivity.h`.

In a separate commit, I'll migrate the rest of flecsi to use the new names for the `entity_base...` types.