### PR TITLE
Remove mesh_ prefix from mesh_entity_base* in non-mesh specific code

### DIFF
--- a/flecsi/data/dense_accessor.h
+++ b/flecsi/data/dense_accessor.h
@@ -222,7 +222,7 @@ struct accessor_u<
    \tparam E A complex index type.
 
    This version of the operator is provided to support use with
-   \e flecsi mesh entity types \ref mesh_entity_base_t.
+   \e flecsi entity types \ref entity_base_t.
    */
   template<typename E>
   const T & operator()(E * e) const {
@@ -236,7 +236,7 @@ struct accessor_u<
    \tparam E A complex index type.
 
    This version of the operator is provided to support use with
-   \e flecsi mesh entity types \ref mesh_entity_base_u.
+   \e flecsi entity types \ref entity_base_u.
    */
   template<typename E>
   T & operator()(E * e) {

--- a/flecsi/data/global_accessor.h
+++ b/flecsi/data/global_accessor.h
@@ -95,7 +95,7 @@ struct accessor_u<data::global, T, PERMISSIONS, 0, 0>
    \tparam E A complex index type.
 
    This version of the operator is provided to support use with
-   \e flecsi mesh entity types \ref mesh_entity_base_t.
+   \e flecsi entity types \ref entity_base_t.
    */
   template<typename E>
   const T & operator()(E * e) const {
@@ -109,7 +109,7 @@ struct accessor_u<data::global, T, PERMISSIONS, 0, 0>
    \tparam E A complex index type.
 
    This version of the operator is provided to support use with
-   \e flecsi mesh entity types \ref mesh_entity_base_t.
+   \e flecsi entity types \ref entity_base_t.
    */
 
   template<typename E>
@@ -169,7 +169,7 @@ struct accessor_u<data::color, T, PERMISSIONS, 0, 0>
    \tparam E A complex index type.
 
    This version of the operator is provided to support use with
-   \e flecsi mesh entity types \ref mesh_entity_base_t.
+   \e flecsi entity types \ref entity_base_t.
    */
   template<typename E>
   const T & operator()(E * e) const {
@@ -183,7 +183,7 @@ struct accessor_u<data::color, T, PERMISSIONS, 0, 0>
    \tparam E A complex index type.
 
    This version of the operator is provided to support use with
-   \e flecsi mesh entity types \ref mesh_entity_base_t.
+   \e flecsi entity types \ref entity_base_t.
    */
   template<typename E>
   T & operator()(E * e) {

--- a/flecsi/data/hpx/dense.h
+++ b/flecsi/data/hpx/dense.h
@@ -150,7 +150,7 @@ struct dense_handle_t : public dense_data_handle_u<T, EP, SP, GP> {
   /// \tparam E A complex index type.
   ///
   /// This version of the operator is provided to support use with
-  /// \e flecsi mesh entity types \ref mesh_entity_base_t.
+  /// \e flecsi entity types \ref entity_base_t.
   ///
   template<typename E>
   const T & operator[](E * e) const {
@@ -164,7 +164,7 @@ struct dense_handle_t : public dense_data_handle_u<T, EP, SP, GP> {
   /// \tparam E A complex index type.
   ///
   /// This version of the operator is provided to support use with
-  /// \e flecsi mesh entity types \ref mesh_entity_base_t.
+  /// \e flecsi entity types \ref entity_base_t.
   ///
   template<typename E>
   T & operator[](E * e) {
@@ -178,7 +178,7 @@ struct dense_handle_t : public dense_data_handle_u<T, EP, SP, GP> {
   /// \tparam E A complex index type.
   ///
   /// This version of the operator is provided to support use with
-  /// \e flecsi mesh entity types \ref mesh_entity_base_t.
+  /// \e flecsi entity types \ref entity_base_t.
   ///
   template<typename E>
   const T & operator()(E * e) const {
@@ -192,7 +192,7 @@ struct dense_handle_t : public dense_data_handle_u<T, EP, SP, GP> {
   /// \tparam E A complex index type.
   ///
   /// This version of the operator is provided to support use with
-  /// \e flecsi mesh entity types \ref mesh_entity_base_t.
+  /// \e flecsi entity types \ref entity_base_t.
   ///
   template<typename E>
   T & operator()(E * e) {
@@ -294,7 +294,7 @@ struct dense_handle_t : public dense_data_handle_u<T, EP, SP, GP> {
   //  // \tparam E A complex index type.
   //  //
   //  // This version of the operator is provided to support use with
-  //  // \e flecsi mesh entity types \ref mesh_entity_base_t.
+  //  // \e flecsi entity types \ref entity_base_t.
   //  ///
   //  template<typename E>
   //  const T &
@@ -312,7 +312,7 @@ struct dense_handle_t : public dense_data_handle_u<T, EP, SP, GP> {
   //  // \tparam E A complex index type.
   //  //
   //  // This version of the operator is provided to support use with
-  //  // \e flecsi mesh entity types \ref mesh_entity_base_t.
+  //  // \e flecsi entity types \ref entity_base_t.
   //  ///
   //  template<typename E>
   //  T &

--- a/flecsi/execution/legion/init_handles.h
+++ b/flecsi/execution/legion/init_handles.h
@@ -387,7 +387,7 @@ struct init_handles_t : public utils::tuple_walker_u<init_handles_t> {
 
       auto ents_raw =
           static_cast<uint8_t *>(ac.template raw_rect_ptr<2>(dr, sr, bo));
-      auto ents = reinterpret_cast<topology::mesh_entity_base_ *>(ents_raw);
+      auto ents = reinterpret_cast<topology::entity_base_ *>(ents_raw);
 
       size_t num_ents = sr.hi[1] - sr.lo[1] + 1;
 

--- a/flecsi/execution/mpi/task_prolog.h
+++ b/flecsi/execution/mpi/task_prolog.h
@@ -218,7 +218,7 @@ namespace execution {
                                                                size);
         }
         auto ents =
-          reinterpret_cast<topology::mesh_entity_base_*>(registered_field_data[ent.fid].data());
+          reinterpret_cast<topology::entity_base_*>(registered_field_data[ent.fid].data());
 
         fieldDataIter = registered_field_data.find(ent.id_fid);
         if (fieldDataIter == registered_field_data.end()) {

--- a/flecsi/topology/hpx/storage_policy.h
+++ b/flecsi/topology/hpx/storage_policy.h
@@ -30,7 +30,7 @@
 namespace flecsi {
 namespace topology {
 
-class mesh_entity_base_;
+class entity_base_;
 
 template<size_t, size_t>
 class mesh_entity_t;
@@ -47,7 +47,7 @@ struct hpx_topology_storage_policy_u {
 
   using index_spaces_t = std::array<
       index_space_u<
-          mesh_entity_base_ *,
+          entity_base_ *,
           true,
           true,
           true,
@@ -57,7 +57,7 @@ struct hpx_topology_storage_policy_u {
 
   using index_subspaces_t = std::array<
       index_space_u<
-          mesh_entity_base_ *,
+          entity_base_ *,
           false,
           true,
           false,
@@ -67,7 +67,7 @@ struct hpx_topology_storage_policy_u {
 
   using partition_index_spaces_t = std::array<
       index_space_u<
-          mesh_entity_base_ *,
+          entity_base_ *,
           false,
           false,
           true,

--- a/flecsi/topology/legion/storage_policy.h
+++ b/flecsi/topology/legion/storage_policy.h
@@ -52,7 +52,7 @@ struct legion_topology_storage_policy_t_u {
 
   using index_spaces_t = std::array<
       index_space_u<
-          mesh_entity_base_ *,
+          entity_base_ *,
           true,
           true,
           true,
@@ -62,7 +62,7 @@ struct legion_topology_storage_policy_t_u {
 
   using index_subspaces_t = std::array<
       index_space_u<
-          mesh_entity_base_ *,
+          entity_base_ *,
           false,
           true,
           false,
@@ -72,7 +72,7 @@ struct legion_topology_storage_policy_t_u {
 
   using partition_index_spaces_t = std::array<
       index_space_u<
-          mesh_entity_base_ *,
+          entity_base_ *,
           false,
           false,
           true,
@@ -103,7 +103,7 @@ struct legion_topology_storage_policy_t_u {
   void init_entities(
       size_t domain,
       size_t dim,
-      mesh_entity_base_ * entities,
+      entity_base_ * entities,
       utils::id_t * ids,
       size_t size,
       size_t num_entities,

--- a/flecsi/topology/mpi/storage_policy.h
+++ b/flecsi/topology/mpi/storage_policy.h
@@ -45,7 +45,7 @@ struct mpi_topology_storage_policy_u {
 
   using index_spaces_t = std::array<
       index_space_u<
-          mesh_entity_base_ *,
+          entity_base_ *,
           true,
           true,
           true,
@@ -55,7 +55,7 @@ struct mpi_topology_storage_policy_u {
 
   using index_subspaces_t = std::array<
       index_space_u<
-          mesh_entity_base_ *,
+          entity_base_ *,
           false,
           true,
           false,
@@ -65,7 +65,7 @@ struct mpi_topology_storage_policy_u {
 
   using partition_index_spaces_t = std::array<
       index_space_u<
-          mesh_entity_base_ *,
+          entity_base_ *,
           false,
           false,
           true,
@@ -94,7 +94,7 @@ struct mpi_topology_storage_policy_u {
   void init_entities(
       size_t domain,
       size_t dim,
-      mesh_entity_base_ * entities,
+      entity_base_ * entities,
       utils::id_t * ids,
       size_t size,
       size_t num_entities,


### PR DESCRIPTION
This is a continuation of #491 . It replaces references to the mesh_entity_base* classes to the new entity_base* classes in any code that isn't specific to meshes, so that the code can be used for other topologies such as graphs.