### PR TITLE
common.h was removed from header list

### DIFF
--- a/flecsi/utils/CMakeLists.txt
+++ b/flecsi/utils/CMakeLists.txt
@@ -21,6 +21,7 @@ set(utils_HEADERS
   array_ref.h
   bit_buffer.h
   checksum.h
+  common.h
   const_string.h
   dag.h
   debruijn.h


### PR DESCRIPTION
Needs to be installed for other applications.