### PR TITLE
Fix formatting for recently added ragged/sparse code

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,8 +62,8 @@ before_script:
     #- git submodule init
     #- git config submodule.cinch.url https://github.com/laristra/cinch.git
     #- git submodule update --init --recursive
-    - mkdir ${CI_PROJECT_DIR}/ccache
-    - mkdir ${CI_PROJECT_DIR}/build
+    - mkdir -p ${CI_PROJECT_DIR}/ccache
+    - mkdir -p ${CI_PROJECT_DIR}/build
     - cd build
     - ccache -z
     - | 
@@ -81,7 +81,7 @@ before_script:
     - make -k VERBOSE=1 -j2 -l80
     - ccache -s
     - make doxygen
-    - mkdir ${CI_PROJECT_DIR}/install
+    - mkdir -p ${CI_PROJECT_DIR}/install
     - make install DESTDIR=${CI_PROJECT_DIR}/install 
     - sudo make install 
 

--- a/flecsi/data/common/data_types.h
+++ b/flecsi/data/common/data_types.h
@@ -45,7 +45,8 @@ struct sparse_entry_value_u {
 
 template<typename T>
 std::ostream &
-operator<<(std::ostream & ostr, const flecsi::data::sparse_entry_value_u<T> & ev) {
+operator<<(std::ostream & ostr,
+  const flecsi::data::sparse_entry_value_u<T> & ev) {
   return ostr << "(" << ev.entry << ", " << ev.value << ")";
 } // operator<<
 

--- a/flecsi/data/mpi/sparse.h
+++ b/flecsi/data/mpi/sparse.h
@@ -160,8 +160,7 @@ struct storage_class_u<ragged> {
     hb.index_space = field_info.index_space;
     hb.data_client_hash = field_info.data_client_hash;
 
-    hb.entries =
-      reinterpret_cast<DATA_TYPE *>(&fd.entries[0]);
+    hb.entries = reinterpret_cast<DATA_TYPE *>(&fd.entries[0]);
 
     hb.offsets = &fd.offsets[0];
     hb.max_entries_per_index = fd.max_entries_per_index;
@@ -253,8 +252,8 @@ struct storage_class_u<sparse> {
     size_t NAME,
     size_t VERSION>
   static auto get_handle(const data_client_t & data_client) {
-    return storage_class_u<ragged>::get_handle<DATA_CLIENT_TYPE, entry_value_u<DATA_TYPE>,
-      NAMESPACE, NAME, VERSION>(data_client);
+    return storage_class_u<ragged>::get_handle<DATA_CLIENT_TYPE,
+      entry_value_u<DATA_TYPE>, NAMESPACE, NAME, VERSION>(data_client);
   }
 
   template<typename DATA_CLIENT_TYPE,
@@ -263,8 +262,8 @@ struct storage_class_u<sparse> {
     size_t NAME,
     size_t VERSION>
   static auto get_mutator(const data_client_t & data_client, size_t slots) {
-    return storage_class_u<ragged>::get_mutator<DATA_CLIENT_TYPE, entry_value_u<DATA_TYPE>,
-      NAMESPACE, NAME, VERSION>(data_client, slots);
+    return storage_class_u<ragged>::get_mutator<DATA_CLIENT_TYPE,
+      entry_value_u<DATA_TYPE>, NAMESPACE, NAME, VERSION>(data_client, slots);
   }
 }; // struct storage_class_t
 

--- a/flecsi/data/ragged_accessor.h
+++ b/flecsi/data/ragged_accessor.h
@@ -119,7 +119,6 @@ struct accessor_u<data::ragged,
   }
 
   handle_t handle;
-
 };
 
 template<typename T,

--- a/flecsi/data/ragged_mutator.h
+++ b/flecsi/data/ragged_mutator.h
@@ -154,8 +154,7 @@ struct mutator_u<data::ragged, T> : public mutator_u<data::base, T>,
     // erase from base area
     auto eptr = h_.entries_ + offset.start();
     size_t ncopy = std::min(n, nnew);
-    std::copy(&eptr[ragged_index + 1], &eptr[ncopy],
-              &eptr[ragged_index]);
+    std::copy(&eptr[ragged_index + 1], &eptr[ncopy], &eptr[ragged_index]);
     if(nnew > n) {
       // shift out of overflow area, if needed
       auto & overflow = h_.overflow_map_->at(index);
@@ -174,7 +173,7 @@ struct mutator_u<data::ragged, T> : public mutator_u<data::base, T>,
 
     h_.new_counts_[index] = nnew + 1;
 
-    if (nnew >= n) {
+    if(nnew >= n) {
       // add to overflow area
       auto & overflow = (*h_.overflow_map_)[index];
       overflow.push_back(value);
@@ -202,21 +201,19 @@ struct mutator_u<data::ragged, T> : public mutator_u<data::base, T>,
       // insert in overflow area
       auto & overflow = (*h_.overflow_map_)[index];
       assert(ragged_index - n <= overflow.size());
-      auto itr = overflow.insert(
-              overflow.begin() + (ragged_index - n), value);
+      auto itr = overflow.insert(overflow.begin() + (ragged_index - n), value);
       return &(*itr);
     }
 
     // insert in base area
     auto eptr = h_.entries_ + offset.start();
-    if (nnew >= n) {
+    if(nnew >= n) {
       // shift into overflow area, if needed
       auto & overflow = (*h_.overflow_map_)[index];
       overflow.insert(overflow.begin(), eptr[n - 1]);
     }
     size_t ncopy = std::min(n - 1, nnew);
-    std::copy_backward(&eptr[ragged_index], &eptr[ncopy],
-                       &eptr[ncopy + 1]);
+    std::copy_backward(&eptr[ragged_index], &eptr[ncopy], &eptr[ncopy + 1]);
     eptr[ragged_index] = value;
     return &eptr[ragged_index];
   } // insert

--- a/flecsi/data/sparse_accessor.h
+++ b/flecsi/data/sparse_accessor.h
@@ -22,8 +22,8 @@
 #include <cinchlog.h>
 
 #include <flecsi/data/accessor.h>
-#include <flecsi/data/sparse_data_handle.h>
 #include <flecsi/data/common/data_types.h>
+#include <flecsi/data/sparse_data_handle.h>
 #include <flecsi/topology/index_space.h>
 
 namespace flecsi {
@@ -78,10 +78,10 @@ struct accessor_u<data::sparse,
   using entry_value_t = data::sparse_entry_value_u<T>;
 
   using base_t = accessor_u<data::ragged,
-                            entry_value_t,
-                            EXCLUSIVE_PERMISSIONS,
-                            SHARED_PERMISSIONS,
-                            GHOST_PERMISSIONS>;
+    entry_value_t,
+    EXCLUSIVE_PERMISSIONS,
+    SHARED_PERMISSIONS,
+    GHOST_PERMISSIONS>;
 
   using index_space_t =
     topology::index_space_u<topology::simple_entry_u<size_t>, true>;
@@ -97,8 +97,7 @@ struct accessor_u<data::sparse,
 
   T & operator()(size_t index, size_t entry) {
     auto itr = lower_bound(index, entry);
-    assert(itr && itr->entry == entry
-               && "sparse accessor: unmapped entry");
+    assert(itr && itr->entry == entry && "sparse accessor: unmapped entry");
 
     return itr->value;
   } // operator ()
@@ -141,10 +140,11 @@ struct accessor_u<data::sparse,
     const entry_value_t * end = start + oi.count();
 
     // find where entry should be
-    const entry_value_t * itr = std::lower_bound(start, end, entry_value_t(entry),
-      [](const entry_value_t & k1, const entry_value_t & k2) -> bool {
-        return k1.entry < k2.entry;
-      });
+    const entry_value_t * itr =
+      std::lower_bound(start, end, entry_value_t(entry),
+        [](const entry_value_t & k1, const entry_value_t & k2) -> bool {
+          return k1.entry < k2.entry;
+        });
 
     return (itr == end ? nullptr : itr);
 
@@ -266,7 +266,6 @@ struct accessor_u<data::sparse,
     auto & handle = base_t::handle;
     return handle.max_entries_per_index;
   }
-
 };
 
 template<typename T,

--- a/flecsi/data/sparse_data_handle.h
+++ b/flecsi/data/sparse_data_handle.h
@@ -124,19 +124,20 @@ template<typename T,
   size_t SHARED_PERMISSIONS,
   size_t GHOST_PERMISSIONS,
   typename DATA_POLICY>
-struct sparse_data_handle_base_u : public ragged_data_handle_base_u<data::sparse_entry_value_u<T>,
-                                     EXCLUSIVE_PERMISSIONS,
-                                     SHARED_PERMISSIONS,
-                                     GHOST_PERMISSIONS,
-                                     FLECSI_RUNTIME_SPARSE_DATA_HANDLE_POLICY> {
+struct sparse_data_handle_base_u
+  : public ragged_data_handle_base_u<data::sparse_entry_value_u<T>,
+      EXCLUSIVE_PERMISSIONS,
+      SHARED_PERMISSIONS,
+      GHOST_PERMISSIONS,
+      FLECSI_RUNTIME_SPARSE_DATA_HANDLE_POLICY> {
 
   using offset_t = data::sparse_data_offset_t;
   using entry_value_t = data::sparse_entry_value_u<T>;
   using base_t = ragged_data_handle_base_u<entry_value_t,
-                                           EXCLUSIVE_PERMISSIONS,
-                                           SHARED_PERMISSIONS,
-                                           GHOST_PERMISSIONS,
-                                           FLECSI_RUNTIME_SPARSE_DATA_HANDLE_POLICY>;
+    EXCLUSIVE_PERMISSIONS,
+    SHARED_PERMISSIONS,
+    GHOST_PERMISSIONS,
+    FLECSI_RUNTIME_SPARSE_DATA_HANDLE_POLICY>;
 
   /*!
     Capture the underlying data type.
@@ -158,8 +159,7 @@ struct sparse_data_handle_base_u : public ragged_data_handle_base_u<data::sparse
   //! Copy constructor.
   //--------------------------------------------------------------------------//
 
-  sparse_data_handle_base_u(const sparse_data_handle_base_u & b)
-    : base_t(b) {};
+  sparse_data_handle_base_u(const sparse_data_handle_base_u & b) : base_t(b){};
 
 }; // sparse_data_handle_base_u
 

--- a/flecsi/data/sparse_mutator.h
+++ b/flecsi/data/sparse_mutator.h
@@ -52,8 +52,9 @@ struct sparse_mutator_base_t {};
 //----------------------------------------------------------------------------//
 
 template<typename T>
-struct mutator_u<data::sparse, T> : public mutator_u<data::ragged, data::sparse_entry_value_u<T>>,
-                                    public sparse_mutator_base_t {
+struct mutator_u<data::sparse, T>
+  : public mutator_u<data::ragged, data::sparse_entry_value_u<T>>,
+    public sparse_mutator_base_t {
   using entry_value_t = data::sparse_entry_value_u<T>;
   using handle_t = mutator_handle_u<entry_value_t>;
   using offset_t = typename handle_t::offset_t;
@@ -114,17 +115,16 @@ struct mutator_u<data::sparse, T> : public mutator_u<data::ragged, data::sparse_
         size_t nbase = std::min(n, nnew);
         std::cout << "  index: " << i << std::endl;
         for(size_t j = 0; j < nbase; ++j) {
-          std::cout << "    " << h_.entries_[ostart + j].entry
-                    << " = " << h_.entries_[ostart + j].value
-                    << std::endl;
+          std::cout << "    " << h_.entries_[ostart + j].entry << " = "
+                    << h_.entries_[ostart + j].value << std::endl;
         }
 
-        if (nnew <= n) continue;
+        if(nnew <= n)
+          continue;
 
-        const auto& overflow = h_.overflow_map_->at(i);
-        for(const auto& ev : overflow) {
-          std::cout << "    +" << ev.entry
-                    << " = " << ev.value << std::endl;
+        const auto & overflow = h_.overflow_map_->at(i);
+        for(const auto & ev : overflow) {
+          std::cout << "    +" << ev.entry << " = " << ev.value << std::endl;
         }
       }
     }
@@ -148,7 +148,8 @@ struct mutator_u<data::sparse, T> : public mutator_u<data::ragged, data::sparse_
 
   // for row 'index', return pointer to first entry not less
   // than 'entry'
-  entry_value_t * lower_bound(size_t index, size_t entry, size_t * pos = nullptr) {
+  entry_value_t *
+  lower_bound(size_t index, size_t entry, size_t * pos = nullptr) {
     auto & h_ = base_t::h_;
     assert(h_.offsets_ && "uninitialized mutator");
     assert(index < h_.num_entries_);
@@ -162,8 +163,7 @@ struct mutator_u<data::sparse, T> : public mutator_u<data::ragged, data::sparse_
     entry_value_t * end = start + std::min(n, nnew);
 
     // try to find entry in overflow, if appropriate
-    bool use_overflow = (nnew > n &&
-            (n == 0 || entry > end[-1].entry));
+    bool use_overflow = (nnew > n && (n == 0 || entry > end[-1].entry));
     if(use_overflow) {
       auto & overflow = h_.overflow_map_->at(index);
       start = overflow.data();
@@ -178,7 +178,8 @@ struct mutator_u<data::sparse, T> : public mutator_u<data::ragged, data::sparse_
 
     if(pos) {
       size_t ragged_idx = itr - start;
-      if(use_overflow) ragged_idx += n;
+      if(use_overflow)
+        ragged_idx += n;
       *pos = ragged_idx;
     }
 
@@ -202,8 +203,7 @@ struct mutator_u<data::sparse, T> : public mutator_u<data::ragged, data::sparse_
     const entry_value_t * end = start + std::min(n, nnew);
 
     // try to find entry in overflow, if appropriate
-    bool use_overflow = (nnew > n &&
-            (n == 0 || entry > end[-1].entry));
+    bool use_overflow = (nnew > n && (n == 0 || entry > end[-1].entry));
     if(use_overflow) {
       auto & overflow = h_.overflow_map_->at(index);
       start = overflow.data();
@@ -211,10 +211,11 @@ struct mutator_u<data::sparse, T> : public mutator_u<data::ragged, data::sparse_
     }
 
     // find where entry should be
-    const entry_value_t * itr = std::lower_bound(start, end, entry_value_t(entry),
-      [](const entry_value_t & e1, const entry_value_t & e2) -> bool {
-        return e1.entry < e2.entry;
-      });
+    const entry_value_t * itr =
+      std::lower_bound(start, end, entry_value_t(entry),
+        [](const entry_value_t & e1, const entry_value_t & e2) -> bool {
+          return e1.entry < e2.entry;
+        });
 
     return (itr == end ? nullptr : itr);
 
@@ -252,10 +253,11 @@ struct mutator_u<data::sparse, T> : public mutator_u<data::ragged, data::sparse_
         }
         ++itr;
       }
-      if(nnew <= n) continue;
+      if(nnew <= n)
+        continue;
 
-      const auto& overflow = h_.overflow_map_->at(index);
-      for(const auto& ev : overflow) {
+      const auto & overflow = h_.overflow_map_->at(index);
+      for(const auto & ev : overflow) {
         size_t entry = ev.entry;
         if(found.find(entry) == found.end()) {
           is.push_back({id++, entry});
@@ -272,8 +274,7 @@ struct mutator_u<data::sparse, T> : public mutator_u<data::ragged, data::sparse_
   //-------------------------------------------------------------------------//
   index_space_t entries(size_t index) const {
     auto & h_ = base_t::h_;
-    clog_assert(
-      index < h_.num_total_, "sparse mutator: index out of bounds");
+    clog_assert(index < h_.num_total_, "sparse mutator: index out of bounds");
 
     const offset_t & oi = h_.offsets[index];
     size_t n = oi.count();
@@ -290,10 +291,11 @@ struct mutator_u<data::sparse, T> : public mutator_u<data::ragged, data::sparse_
       is.push_back({id++, itr->entry});
       ++itr;
     }
-    if(nnew <= n) return is;
+    if(nnew <= n)
+      return is;
 
-    const auto& overflow = h_.overflow_map_->at(index);
-    for(const auto& ev : overflow) {
+    const auto & overflow = h_.overflow_map_->at(index);
+    for(const auto & ev : overflow) {
       is.push_back({id++, ev.entry});
     }
 

--- a/flecsi/execution/legion/finalize_handles.h
+++ b/flecsi/execution/legion/finalize_handles.h
@@ -69,15 +69,14 @@ struct finalize_handles_t
     auto & h = a.handle;
     auto md = static_cast<sparse_field_data_t *>(h.metadata);
 
-    std::memcpy(h.entries_data[0], h.entries,
-      md->num_exclusive_filled * sizeof(value_t));
+    std::memcpy(
+      h.entries_data[0], h.entries, md->num_exclusive_filled * sizeof(value_t));
 
     std::memcpy(h.entries_data[1], h.entries + md->reserve,
       md->num_shared * sizeof(value_t) * md->max_entries_per_index);
   } // handle
 
-  template<
-    typename T,
+  template<typename T,
     size_t EXCLUSIVE_PERMISSIONS,
     size_t SHARED_PERMISSIONS,
     size_t GHOST_PERMISSIONS>
@@ -85,8 +84,8 @@ struct finalize_handles_t
     EXCLUSIVE_PERMISSIONS,
     SHARED_PERMISSIONS,
     GHOST_PERMISSIONS> & a) {
-    using base_t = typename sparse_accessor<
-            T, EXCLUSIVE_PERMISSIONS, SHARED_PERMISSIONS, GHOST_PERMISSIONS>::base_t;
+    using base_t = typename sparse_accessor<T, EXCLUSIVE_PERMISSIONS,
+      SHARED_PERMISSIONS, GHOST_PERMISSIONS>::base_t;
     handle(static_cast<base_t &>(a));
   } // handle
 
@@ -123,11 +122,10 @@ struct finalize_handles_t
         h.num_ghost() * sizeof(offset_t));
     }
 
-    std::memcpy(h.entries_data[0], h.entries,
-      md->num_exclusive_filled * sizeof(value_t));
+    std::memcpy(
+      h.entries_data[0], h.entries, md->num_exclusive_filled * sizeof(value_t));
 
-    std::memcpy(h.entries_data[1],
-      h.entries + h.reserve * sizeof(value_t),
+    std::memcpy(h.entries_data[1], h.entries + h.reserve * sizeof(value_t),
       h.num_shared() * sizeof(value_t) * h.max_entries_per_index());
 
     md->initialized = true;

--- a/flecsi/execution/legion/init_args.h
+++ b/flecsi/execution/legion/init_args.h
@@ -271,8 +271,8 @@ struct init_args_t : public flecsi::utils::tuple_walker_u<init_args_t> {
     EXCLUSIVE_PERMISSIONS,
     SHARED_PERMISSIONS,
     GHOST_PERMISSIONS> & a) {
-    using base_t = typename sparse_accessor<
-            T, EXCLUSIVE_PERMISSIONS, SHARED_PERMISSIONS, GHOST_PERMISSIONS>::base_t;
+    using base_t = typename sparse_accessor<T, EXCLUSIVE_PERMISSIONS,
+      SHARED_PERMISSIONS, GHOST_PERMISSIONS>::base_t;
     handle(static_cast<base_t &>(a));
   } // handle
 

--- a/flecsi/execution/legion/init_handles.h
+++ b/flecsi/execution/legion/init_handles.h
@@ -617,9 +617,8 @@ struct init_handles_t : public flecsi::utils::tuple_walker_u<init_handles_t> {
       Legion::LogicalRegion lr = entries_prs[r].get_logical_region();
       Legion::IndexSpace is = lr.get_index_space();
 
-      auto ac = entries_prs[r]
-                  .get_field_accessor(h.fid)
-                  .template typeify<value_t>();
+      auto ac =
+        entries_prs[r].get_field_accessor(h.fid).template typeify<value_t>();
 
       Legion::Domain domain = runtime->get_index_space_domain(context, is);
 
@@ -637,8 +636,8 @@ struct init_handles_t : public flecsi::utils::tuple_walker_u<init_handles_t> {
     pos = 0;
 
     for(size_t r{0}; r < num_regions; ++r) {
-      std::memcpy(entries + pos, entries_data[r],
-        entries_sizes[r] * sizeof(value_t));
+      std::memcpy(
+        entries + pos, entries_data[r], entries_sizes[r] * sizeof(value_t));
       pos += entries_sizes[r];
     }
 
@@ -655,8 +654,8 @@ struct init_handles_t : public flecsi::utils::tuple_walker_u<init_handles_t> {
     EXCLUSIVE_PERMISSIONS,
     SHARED_PERMISSIONS,
     GHOST_PERMISSIONS> & a) {
-    using base_t = typename sparse_accessor<
-            T, EXCLUSIVE_PERMISSIONS, SHARED_PERMISSIONS, GHOST_PERMISSIONS>::base_t;
+    using base_t = typename sparse_accessor<T, EXCLUSIVE_PERMISSIONS,
+      SHARED_PERMISSIONS, GHOST_PERMISSIONS>::base_t;
     handle(static_cast<base_t &>(a));
   } // handle
 
@@ -760,9 +759,8 @@ struct init_handles_t : public flecsi::utils::tuple_walker_u<init_handles_t> {
       Legion::LogicalRegion lr = entries_prs[r].get_logical_region();
       Legion::IndexSpace is = lr.get_index_space();
 
-      auto ac = entries_prs[r]
-                  .get_field_accessor(h.fid)
-                  .template typeify<value_t>();
+      auto ac =
+        entries_prs[r].get_field_accessor(h.fid).template typeify<value_t>();
 
       Legion::Domain domain = runtime->get_index_space_domain(context, is);
 
@@ -777,14 +775,14 @@ struct init_handles_t : public flecsi::utils::tuple_walker_u<init_handles_t> {
 
     value_t * entries = new value_t[h.entries_size];
 
-    std::memcpy(entries, entries_data[0],
-      md->num_exclusive_filled * sizeof(value_t));
+    std::memcpy(
+      entries, entries_data[0], md->num_exclusive_filled * sizeof(value_t));
 
     pos = entries_sizes[0];
 
     for(size_t r{1}; r < num_regions; ++r) {
-      std::memcpy(entries + pos, entries_data[r],
-        entries_sizes[r] * sizeof(value_t));
+      std::memcpy(
+        entries + pos, entries_data[r], entries_sizes[r] * sizeof(value_t));
       pos += entries_sizes[r];
     }
 

--- a/flecsi/execution/legion/task_epilog.h
+++ b/flecsi/execution/legion/task_epilog.h
@@ -126,8 +126,8 @@ struct task_epilog_t : public flecsi::utils::tuple_walker_u<task_epilog_t> {
     EXCLUSIVE_PERMISSIONS,
     SHARED_PERMISSIONS,
     GHOST_PERMISSIONS> & a) {
-    using base_t = typename sparse_accessor<
-            T, EXCLUSIVE_PERMISSIONS, SHARED_PERMISSIONS, GHOST_PERMISSIONS>::base_t;
+    using base_t = typename sparse_accessor<T, EXCLUSIVE_PERMISSIONS,
+      SHARED_PERMISSIONS, GHOST_PERMISSIONS>::base_t;
     handle(static_cast<base_t &>(a));
   } // handle
 

--- a/flecsi/execution/legion/task_prolog.h
+++ b/flecsi/execution/legion/task_prolog.h
@@ -386,8 +386,8 @@ struct task_prolog_t : public flecsi::utils::tuple_walker_u<task_prolog_t> {
     EXCLUSIVE_PERMISSIONS,
     SHARED_PERMISSIONS,
     GHOST_PERMISSIONS> & a) {
-    using base_t = typename sparse_accessor<
-            T, EXCLUSIVE_PERMISSIONS, SHARED_PERMISSIONS, GHOST_PERMISSIONS>::base_t;
+    using base_t = typename sparse_accessor<T, EXCLUSIVE_PERMISSIONS,
+      SHARED_PERMISSIONS, GHOST_PERMISSIONS>::base_t;
     handle(static_cast<base_t &>(a));
   } // handle
 

--- a/flecsi/execution/mpi/finalize_handles.h
+++ b/flecsi/execution/mpi/finalize_handles.h
@@ -62,8 +62,7 @@ struct finalize_handles_t
     auto & sparse_field_metadata =
       context.registered_sparse_field_metadata().at(h.fid);
 
-    value_t * entries =
-      reinterpret_cast<value_t *>(&(*h.entries)[0]);
+    value_t * entries = reinterpret_cast<value_t *>(&(*h.entries)[0]);
     auto offsets = &(*h.offsets)[0];
     auto shared_data = entries + *h.reserve; // ci.entries[1];
     auto ghost_data =

--- a/flecsi/execution/mpi/task_epilog.h
+++ b/flecsi/execution/mpi/task_epilog.h
@@ -126,8 +126,8 @@ struct task_epilog_t : public flecsi::utils::tuple_walker_u<task_epilog_t> {
     GHOST_PERMISSIONS> & a) {
     auto & h = a.handle;
 
-    using accessor_t = ragged_accessor<
-              T, EXCLUSIVE_PERMISSIONS, SHARED_PERMISSIONS, GHOST_PERMISSIONS>;
+    using accessor_t = ragged_accessor<T, EXCLUSIVE_PERMISSIONS,
+      SHARED_PERMISSIONS, GHOST_PERMISSIONS>;
     using handle_t = typename accessor_t::handle_t;
     using offset_t = typename handle_t::offset_t;
     using value_t = T;
@@ -226,18 +226,16 @@ struct task_epilog_t : public flecsi::utils::tuple_walker_u<task_epilog_t> {
     }
   } // handle
 
-  template<
-      typename T,
-      size_t EXCLUSIVE_PERMISSIONS,
-      size_t SHARED_PERMISSIONS,
-      size_t GHOST_PERMISSIONS>
-  void handle(sparse_accessor<
-              T,
-              EXCLUSIVE_PERMISSIONS,
-              SHARED_PERMISSIONS,
-              GHOST_PERMISSIONS> & a) {
-    using base_t = typename sparse_accessor<
-            T, EXCLUSIVE_PERMISSIONS, SHARED_PERMISSIONS, GHOST_PERMISSIONS>::base_t;
+  template<typename T,
+    size_t EXCLUSIVE_PERMISSIONS,
+    size_t SHARED_PERMISSIONS,
+    size_t GHOST_PERMISSIONS>
+  void handle(sparse_accessor<T,
+    EXCLUSIVE_PERMISSIONS,
+    SHARED_PERMISSIONS,
+    GHOST_PERMISSIONS> & a) {
+    using base_t = typename sparse_accessor<T, EXCLUSIVE_PERMISSIONS,
+      SHARED_PERMISSIONS, GHOST_PERMISSIONS>::base_t;
     handle(static_cast<base_t &>(a));
   } // handle
 
@@ -257,8 +255,7 @@ struct task_epilog_t : public flecsi::utils::tuple_walker_u<task_epilog_t> {
     // this segfaults if we try to use a sparse mutator more than once
     // delete h.num_exclusive_insertions;
 
-    value_t * entries =
-      reinterpret_cast<value_t *>(&(*h.entries)[0]);
+    value_t * entries = reinterpret_cast<value_t *>(&(*h.entries)[0]);
 
     commit_info_t ci;
     ci.offsets = &(*h.offsets)[0];

--- a/flecsi/execution/mpi/task_prolog.h
+++ b/flecsi/execution/mpi/task_prolog.h
@@ -1,16 +1,16 @@
-    /*
-    @@@@@@@@  @@           @@@@@@   @@@@@@@@ @@
-   /@@/////  /@@          @@////@@ @@////// /@@
-   /@@       /@@  @@@@@  @@    // /@@       /@@
-   /@@@@@@@  /@@ @@///@@/@@       /@@@@@@@@@/@@
-   /@@////   /@@/@@@@@@@/@@       ////////@@/@@
-   /@@       /@@/@@//// //@@    @@       /@@/@@
-   /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
-   //       ///  //////   //////  ////////  //
+/*
+@@@@@@@@  @@           @@@@@@   @@@@@@@@ @@
+/@@/////  /@@          @@////@@ @@////// /@@
+/@@       /@@  @@@@@  @@    // /@@       /@@
+/@@@@@@@  /@@ @@///@@/@@       /@@@@@@@@@/@@
+/@@////   /@@/@@@@@@@/@@       ////////@@/@@
+/@@       /@@/@@//// //@@    @@       /@@/@@
+/@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@
+//       ///  //////   //////  ////////  //
 
-   Copyright (c) 2016, Los Alamos National Security, LLC
-   All rights reserved.
-                                                                              */
+Copyright (c) 2016, Los Alamos National Security, LLC
+All rights reserved.
+                                                                          */
 #pragma once
 
 /*! @file */
@@ -131,8 +131,8 @@ struct task_prolog_t : public flecsi::utils::tuple_walker_u<task_prolog_t> {
     EXCLUSIVE_PERMISSIONS,
     SHARED_PERMISSIONS,
     GHOST_PERMISSIONS> & a) {
-    using base_t = typename sparse_accessor<
-            T, EXCLUSIVE_PERMISSIONS, SHARED_PERMISSIONS, GHOST_PERMISSIONS>::base_t;
+    using base_t = typename sparse_accessor<T, EXCLUSIVE_PERMISSIONS,
+      SHARED_PERMISSIONS, GHOST_PERMISSIONS>::base_t;
     handle(static_cast<base_t &>(a));
   } // handle
 


### PR DESCRIPTION
I neglected to run clang-format on my previous PR.  Sorry about that.  This PR fixes it - no changes to functionality, just formatting.