### PR TITLE
Tweak ABC mesh_definition_u

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,131 +1,617 @@
+###################
+# Global Settings #
+###################
+
 stages:
-  - build
-  - test
-  - format
-  - deploy
+  - Canary
+  - Build
+  - Test
+  - Format
+  - Apps
 
-build_ubuntu_mpi:
+variables:
+  GET_SOURCES_ATTEMPTS: 10
+  ARTIFACT_DOWNLOAD_ATTEMPTS: 10
+  RESTORE_CACHE_ATTEMPTS: 10
+  GIT_STRATEGY: fetch
+  GLOBAL_CI_VARIABLE: "global_ci_value"
+  CI_JOB_NAME_TMP: ${CI_JOB_NAME}
+  CI_JOB_NAME_NOSTAGE: ${CI_JOB_NAME_TMP#*:}
+  #CI_DEBUG_TRACE: "true"
+before_script:
+  - echo ${CI_JOB_NAME_NOSTAGE%.*}-${CI_COMMIT_REF_SLUG}
+  - '[ "$(git rev-parse origin/$CI_COMMIT_REF_NAME)" != "$CI_COMMIT_SHA" ] && curl --header "PRIVATE-TOKEN: $MY_CI_API_TOKEN" -X POST https://gitlab.com/api/v4/projects/$CI_PROJECT_ID/pipelines/$CI_PIPELINE_ID/cancel'
+  #- find . -name "`basename cinch`" | grep "cinch\$" | xargs rm -fr
+
+###################
+###################
+###################
+
+################
+# Canary Stage #
+################
+
+.canary:
+  retry: 2
   variables:
-    GLOBAL_CI_VARIABLE: "global_ci_value"
-    GIT_SUBMODULE_STRATEGY: none
-    DISTRO: "ubuntu"
-    RUNTIME: "mpi"
-    ARTIFACTS_PROJECT_PATH: ${CI_PROJECT_DIR} #/builds/gitlab_account/flecsi
-  image:    
+    GIT_SUBMODULE_STRATEGY: recursive
+    CCACHE_DIR: "${CI_PROJECT_DIR}/ccache"
+    CCACHE_UMASK: 000
+    DISTRO: ""
+    RUNTIME: ""
+    CC: "gcc"
+    CXX: "g++"
+    CXXFLAGS: "-Werror -Wno-deprecated-declarations"
+    BUILD_TYPE: "Debug"
+    IGNORE_NOCI: "FALSE"
+  image:
     name: laristra/flecsi-third-party:${DISTRO} #user: flecsi
-  stage:    build
-  artifacts:
-    expire_in: 1 hour
+  stage: Canary
+  cache:
+    #key: ${CI_JOB_NAME_NOSTAGE%.*}-${CI_COMMIT_REF_SLUG}
+    #key: ${CI_COMMIT_REF_SLUG}
+    key: ${DISTRO}-${RUNTIME}-${CC}
     paths:
-      - ${ARTIFACTS_PROJECT_PATH}
-  script:
-    - git submodule init
-    - git config submodule.cinch.url https://github.com/laristra/cinch.git
-    - git config submodule.ristra-utils.url https://github.com/laristra/ristra-utils
-    - git submodule update --init --recursive
-    - mkdir ${CI_PROJECT_DIR}/build
-    - cd build
-    - | 
-      cmake   -DENABLE_LEGION=$LEGION \
-        -DFLECSI_RUNTIME_MODEL=$RUNTIME \
-         ${MINIMAL:+-DCMAKE_DISABLE_FIND_PACKAGE_METIS=ON}\
-        -DFLECSI_ENABLE_TUTORIAL=$([ "$RUNTIME" = "hpx" ] \
-                && echo OFF || echo ON) \
-        -DENABLE_UNIT_TESTS=ON \
-        -DENABLE_PARMETIS=ON \
-        -DENABLE_COLORING=ON \
-        -DENABLE_DOXYGEN=ON \
-        -DENABLE_DOCUMENTATION=OFF \
-         ${COVERAGE:+-DENABLE_COVERAGE_BUILD=ON} \
-        ..
-    - make doxygen
-    - |
-      if [ ${COVERAGE} ]; 
-      then python -m coverxygen --xml-dir doc/doxygen/xml/ \
-              --src-dir .. \
-              --output doxygen.coverage.info; 
-           wget -O codecov.sh https://codecov.io/bash;
-           bash codecov.sh -X gcov \
-               -f doxygen.coverage.info \
-               -F documentation; 
-           doxy-coverage --threshold 24 doc/doxygen/xml/; 
-      fi
-    - make install DESTDIR=${PWD}/install 
-    - rm -rf ${PWD}/install
-    - cd .. 
-    - |
-      if [ ${COVERAGE} ]; 
-      then if [ ${CC} = clang ]; 
-           then $HOME/.local/bin/codecov -F "${CC}" \
-          --gcov-exec "llvm-cov gcov"; 
-           else $HOME/.local/bin/codecov -F "${CC}"; 
-           fi; 
-      fi
-    - cd build 
-    - sudo make install 
-    - cp -r /usr/local ${CI_PROJECT_DIR}/.
-
-test_ubuntu_mpi:
-  variables:
-    GLOBAL_CI_VARIABLE: "global_ci_value"
-    DISTRO: "ubuntu"
-    RUNTIME: "mpi"
-    ARTIFACTS_PROJECT_PATH: ${CI_PROJECT_DIR} #/builds/gitlab_account/flecsi
-  image:  laristra/flecsi-third-party:${DISTRO} #user: flecsi
-  stage:  test
-  dependencies:
-    - build_ubuntu_mpi 
+      - ccache/
   artifacts:
-    expire_in: 1 hour
+    name: "${CI_COMMIT_REF_SLUG}-${CI_JOB_NAME}"
     paths:
-      - ${ARTIFACTS_PROJECT_PATH}
-  script: 
-    - cd ${CI_PROJECT_DIR}/build/
-    - make test ARGS="-V"
-
-format_ubuntu_mpi:
-  variables:
-    GLOBAL_CI_VARIABLE: "global_ci_value"
-    DISTRO: "ubuntu"
-    RUNTIME: "mpi"
-  image:  laristra/flecsi-third-party:${DISTRO} #user: flecsi
-  stage:  format
-  dependencies:
-    - test_ubuntu_mpi
-  script:
-    - cd ${CI_PROJECT_DIR}/build/
-    - make format-FleCSI && git diff #--exit-code
-
-deploy_ubuntu_mpi:
-  variables:
-    GLOBAL_CI_VARIABLE: "global_ci_value"
-    DISTRO: "ubuntu"
-    RUNTIME: "mpi"
-    ARTIFACTS_PROJECT_PATH: ${CI_PROJECT_DIR} #/builds/gitlab_account/flecsi
-  #services:
-  #  - docker:dind
-  image: gitlab/dind:latest #user: root
-  stage: deploy
-  dependencies:
-    - test_ubuntu_mpi
-  artifacts:
-    expire_in: 1 hour
-    paths:
-      - ${ARTIFACTS_PROJECT_PATH}
+      - ${CI_PROJECT_DIR}/build #/builds/next-generation-codes/laristra/flecsi/build
+    when: always
+  dependencies: []
   script:
     - |
-      if [[ ${CC} != gcc ]]; 
-      then TAG="_${CC}"; 
-      fi
+      if [[ ${CI_JOB_STAGE} = "Canary" || ${CI_JOB_STAGE} = "Build" ]];
+      then
+        ccache -z;
+        nproc;
+        # git submodule init;
+        # git config submodule.cinch.url https://github.com/laristra/cinch.git;
+        # git submodule update --init --recursive;
+        mkdir -p build;
+        cd build;
+        cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -DFLECSI_RUNTIME_MODEL=$RUNTIME \
+          ${MINIMAL:+-DCMAKE_DISABLE_FIND_PACKAGE_METIS=ON} \
+          -DFLECSI_ENABLE_TUTORIAL=$([ "$RUNTIME" = "hpx" ] && echo OFF || echo ON) \
+          -DENABLE_UNIT_TESTS=ON \
+          -DENABLE_PARMETIS=ON \
+          -DENABLE_COLORING=ON \
+          -DENABLE_DOXYGEN=ON \
+          -DENABLE_DOCUMENTATION=OFF \
+          -DENABLE_COVERAGE_BUILD=ON \
+          ..;
+        make -k VERBOSE=1 -j2 -l80;
+        make doxygen;
+        mkdir -p install;
+        make install DESTDIR=install;
+        sudo make install;
+        ccache -s;
+      fi;
     - |
-      if [[ ${CI_COMMIT_REF_NAME} != stable ]]; 
-      then TAG="${TAG}_${CI_COMMIT_REF_NAME//\//_}"; 
-      fi
-    - docker pull laristra/flecsi-third-party:${DISTRO} 
-    - CON=$(docker run -d laristra/flecsi-third-party:${DISTRO} /bin/bash) 
-    - docker cp /builds ${CON}:/.
-    - docker cp ${CI_PROJECT_DIR}/local ${CON}:/usr/local
-    - rm -r ${CI_PROJECT_DIR}/local
-    - docker cp ${CI_PROJECT_DIR} ${CON}:/home/flecsi
-    #- docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-    #- docker push "${CI_COMMIT_REF_SLUG}:${DISTRO}_${RUNTIME}${TAG}
+      if [[ ${CI_JOB_STAGE} = "Canary" || ${CI_JOB_STAGE} = "Test" ]];
+      then
+        cd ${CI_PROJECT_DIR}/build/;
+        make test ARGS="-V";
+        $HOME/.local/bin/gcovr .;
+      fi;
+    - |
+      if [[ ${CI_JOB_STAGE} = "Canary" || ${CI_JOB_STAGE} = "Format" ]];
+      then
+        cd ${CI_PROJECT_DIR}/build/;
+        clang-format -version;
+        make format && git diff --exit-code --ignore-submodules;
+      fi;
+    - |
+      if [[ ${CI_JOB_STAGE} = "Canary" ]];
+      then
+        git clone https://github.com/laristra/flecsale.git;
+        cd flecsale/flecsi;
+        git pull origin master;
+        git submodule update --init --recursive;
+        cd ../;
+        mkdir build;
+        cd build;
+        cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+          -DFLECSI_RUNTIME_MODEL=mpi \
+          -DENABLE_UNIT_TESTS=ON \
+          ..;
+        make -j2 || make VERBOSE=1;
+        if [[ ${RUNTIME} = "mpi" ]];
+        then
+          make test ARGS="CTEST_OUTPUT_ON_FAILURE=1";
+        fi;
+      fi;
+
+###############
+# Build Stage #
+###############
+
+.build:
+  extends: .canary
+  stage: Build
+
+##############
+# Test Stage #
+##############
+
+.test:
+  extends: .canary
+  stage: Test
+  dependencies:
+    #- "build:${CI_JOB_NAME#*:}"
+    - .build
+
+################
+# Format Stage #
+################
+
+.format:
+  extends: .canary
+  stage: Format
+  dependencies:
+    #- build:${CI_JOB_NAME#*:}
+    - .build
+
+################
+################
+################
+
+###############
+# Canary Jobs #
+###############
+
+canary:fedora_mpi:
+  extends: .canary
+  variables:
+    DISTRO: "fedora"
+    RUNTIME: "mpi"
+
+canary:fedora_legion:
+  extends: .canary
+  variables:
+    DISTRO: "fedora"
+    RUNTIME: "legion"
+
+##############
+# Build Jobs #
+##############
+
+build:ubuntu_mpi:
+  extends: .build
+  variables:
+    DISTRO: "ubuntu"
+    RUNTIME: "mpi"
+
+build:ubuntu_mpi_release:
+  extends: build:ubuntu_mpi
+  variables:
+    BUILD_TYPE: "Release"
+
+build:ubuntu_mpi_clang:
+  extends: build:ubuntu_mpi
+  #before_script:
+  #  - export CC=clang
+  #  - export CXX=clang++
+  variables:
+    CC: clang
+    CXX: clang++
+
+build:ubuntu_mpi_clang_release:
+  extends: build:ubuntu_mpi_clang
+  variables:
+    BUILD_TYPE: "Release"
+
+build:ubuntu_mpich_mpi:
+  extends: .build
+  variables:
+    DISTRO: "ubuntu_mpich"
+    RUNTIME: "mpi"
+
+build:ubuntu_mpich_mpi_release:
+  extends: build:ubuntu_mpich_mpi
+  variables:
+    BUILD_TYPE: "Release"
+
+build:ubuntu_mpich_mpi_clang:
+  extends: build:ubuntu_mpich_mpi
+  variables:
+    CC: clang
+    CXX: clang++
+
+build:ubuntu_mpich_mpi_clang_release:
+  extends: build:ubuntu_mpich_mpi_clang
+  variables:
+    BUILD_TYPE: "Release"
+
+build:fedora_mpi:
+  extends: .build
+  variables:
+    DISTRO: "fedora"
+    RUNTIME: "mpi"
+
+build:fedora_mpi_release:
+  extends: build:fedora_mpi
+  variables:
+    BUILD_TYPE: "Release"
+
+build:fedora_mpi_clang:
+  extends: build:fedora_mpi
+  variables:
+    CC: clang
+    CXX: clang++
+
+build:fedora_mpi_clang_release:
+  extends: build:fedora_mpi_clang
+  variables:
+    BUILD_TYPE: "Release"
+
+build:fedora_mpich_mpi:
+  extends: .build
+  variables:
+    DISTRO: "fedora_mpich"
+    RUNTIME: "mpi"
+
+build:fedora_mpich_mpi_release:
+  extends: build:fedora_mpich_mpi
+  variables:
+    BUILD_TYPE: "Release"
+
+build:fedora_mpich_mpi_clang:
+  extends: build:fedora_mpich_mpi
+  variables:
+    CC: clang
+    CXX: clang++
+
+build:fedora_mpich_mpi_clang_release:
+  extends: build:fedora_mpich_mpi_clang
+  variables:
+    BUILD_TYPE: "Release"
+
+build:ubuntu_legion:
+  extends: .build
+  variables:
+    DISTRO: "ubuntu"
+    RUNTIME: "legion"
+
+build:ubuntu_legion_release:
+  extends: build:ubuntu_legion
+  variables:
+    BUILD_TYPE: "Release"
+
+build:ubuntu_legion_clang:
+  extends: build:ubuntu_legion
+  variables:
+    CC: clang
+    CXX: clang++
+
+build:ubuntu_legion_clang_release:
+  extends: build:ubuntu_legion_clang
+  variables:
+    BUILD_TYPE: "Release"
+
+build:ubuntu_mpich_legion:
+  extends: .build
+  variables:
+    DISTRO: "ubuntu_mpich"
+    RUNTIME: "legion"
+
+build:ubuntu_mpich_legion_release:
+  extends: build:ubuntu_mpich_legion
+  variables:
+    BUILD_TYPE: "Release"
+
+build:ubuntu_mpich_legion_clang:
+  extends: build:ubuntu_mpich_legion
+  variables:
+    CC: clang
+    CXX: clang++
+
+build:ubuntu_mpich_legion_clang_release:
+  extends: build:ubuntu_mpich_legion_clang
+  variables:
+    BUILD_TYPE: "Release"
+
+build:fedora_legion:
+  extends: .build
+  variables:
+    DISTRO: "fedora"
+    RUNTIME: "legion"
+
+build:fedora_legion_release:
+  extends: build:fedora_legion
+  variables:
+    BUILD_TYPE: "Release"
+
+build:fedora_legion_clang:
+  extends: build:fedora_legion
+  variables:
+    CC: clang
+    CXX: clang++
+
+build:fedora_legion_clang_release:
+  extends: build:fedora_legion_clang
+  variables:
+    BUILD_TYPE: "Release"
+
+build:fedora_mpich_legion:
+  extends: .build
+  variables:
+    DISTRO: "fedora_mpich"
+    RUNTIME: "legion"
+
+build:fedora_mpich_legion_release:
+  extends: build:fedora_mpich_legion
+  variables:
+    BUILD_TYPE: "Release"
+
+build:fedora_mpich_legion_clang:
+  extends: build:fedora_mpich_legion
+  variables:
+    CC: clang
+    CXX: clang++
+
+build:fedora_mpich_legion_clang_release:
+  extends: build:fedora_mpich_legion_clang
+  variables:
+    BUILD_TYPE: "Release"
+
+build:fedora_hpx:
+  extends: .build
+  variables:
+    DISTRO: "fedora"
+    RUNTIME: "hpx"
+  allow_failure: true
+
+build:fedora_hpx_clang:
+  extends: build:fedora_hpx
+  variables:
+    CC: clang
+    CXX: clang++
+
+#############
+# Test Jobs #
+#############
+
+test:ubuntu_mpi:
+  extends: .test
+  dependencies:
+    - build:ubuntu_mpi
+  variables:
+    DISTRO: "ubuntu"
+
+test:ubuntu_mpi_release:
+  extends: test:ubuntu_mpi
+  dependencies:
+    - build:ubuntu_mpi_release
+
+test:ubuntu_mpi_clang:
+  extends: test:ubuntu_mpi
+  dependencies:
+    - build:ubuntu_mpi_clang
+
+test:ubuntu_mpi_clang_release:
+  extends: test:ubuntu_mpi_clang
+  dependencies:
+    - build:ubuntu_mpi_clang_release
+
+test:ubuntu_mpich_mpi:
+  extends: .test
+  dependencies:
+    - build:ubuntu_mpich_mpi
+  variables:
+    DISTRO: "ubuntu_mpich"
+
+test:ubuntu_mpich_mpi_release:
+  extends: test:ubuntu_mpich_mpi
+  dependencies:
+    - build:ubuntu_mpich_mpi_release
+
+test:ubuntu_mpich_mpi_clang:
+  extends: test:ubuntu_mpich_mpi
+  dependencies:
+    - build:ubuntu_mpich_mpi_clang
+
+test:ubuntu_mpich_mpi_clang_release:
+  extends: test:ubuntu_mpich_mpi_clang
+  dependencies:
+    - build:ubuntu_mpich_mpi_clang_release
+
+test:fedora_mpi:
+  extends: .test
+  dependencies:
+    - build:fedora_mpi
+  variables:
+    DISTRO: "fedora"
+
+test:fedora_mpi_release:
+  extends: test:fedora_mpi
+  dependencies:
+    - build:fedora_mpi_release
+
+test:fedora_mpi_clang:
+  extends: test:fedora_mpi
+  dependencies:
+    - build:fedora_mpi_clang
+
+test:fedora_mpi_clang_release:
+  extends: test:fedora_mpi_clang
+  dependencies:
+    - build:fedora_mpi_clang_release
+
+test:fedora_mpich_mpi:
+  extends: .test
+  dependencies:
+    - build:fedora_mpich_mpi
+  variables:
+    DISTRO: "fedora_mpich"
+
+test:fedora_mpich_mpi_release:
+  extends: test:fedora_mpich_mpi
+  dependencies:
+    - build:fedora_mpich_mpi_release
+
+test:fedora_mpich_mpi_clang:
+  extends: test:fedora_mpich_mpi
+  dependencies:
+    - build:fedora_mpich_mpi_clang
+
+test:fedora_mpich_mpi_clang_release:
+  extends: test:fedora_mpich_mpi_clang
+  dependencies:
+    - build:fedora_mpich_mpi_clang_release
+
+test:ubuntu_legion:
+  extends: .test
+  dependencies:
+    - build:ubuntu_legion
+  variables:
+    DISTRO: "ubuntu"
+
+test:ubuntu_legion_release:
+  extends: test:ubuntu_legion
+  dependencies:
+    - build:ubuntu_legion_release
+
+test:ubuntu_legion_clang:
+  extends: test:ubuntu_legion
+  dependencies:
+    - build:ubuntu_legion_clang
+
+test:ubuntu_legion_clang_release:
+  extends: test:ubuntu_legion_clang
+  dependencies:
+    - build:ubuntu_legion_clang_release
+
+test:ubuntu_mpich_legion:
+  extends: .test
+  dependencies:
+    - build:ubuntu_mpich_legion
+  variables:
+    DISTRO: "ubuntu_mpich"
+
+test:ubuntu_mpich_legion_release:
+  extends: test:ubuntu_mpich_legion
+  dependencies:
+    - build:ubuntu_mpich_legion_release
+
+test:ubuntu_mpich_legion_clang:
+  extends: test:ubuntu_mpich_legion
+  dependencies:
+    - build:ubuntu_mpich_legion_clang
+
+test:ubuntu_mpich_legion_clang_release:
+  extends: test:ubuntu_mpich_legion_clang
+  dependencies:
+    - build:ubuntu_mpich_legion_clang_release
+
+test:fedora_legion:
+  extends: .test
+  dependencies:
+    - build:fedora_legion
+  variables:
+    DISTRO: "fedora"
+
+test:fedora_legion_release:
+  extends: test:fedora_legion
+  dependencies:
+    - build:fedora_legion_release
+
+test:fedora_legion_clang:
+  extends: test:fedora_legion
+  dependencies:
+    - build:fedora_legion_clang
+
+test:fedora_legion_clang_release:
+  extends: test:fedora_legion_clang
+  dependencies:
+    - build:fedora_legion_clang_release
+
+test:fedora_mpich_legion:
+  extends: .test
+  dependencies:
+    - build:fedora_mpich_legion
+  variables:
+    DISTRO: "fedora_mpich"
+
+test:fedora_mpich_legion_release:
+  extends: test:fedora_mpich_legion
+  dependencies:
+    - build:fedora_mpich_legion_release
+
+test:fedora_mpich_legion_clang:
+  extends: test:fedora_mpich_legion
+  dependencies:
+    - build:fedora_mpich_legion_clang
+
+test:fedora_mpich_legion_clang_release:
+  extends: test:fedora_mpich_legion_clang
+  dependencies:
+    - build:fedora_mpich_legion_clang_release
+
+test:fedora_hpx:
+  extends: .test
+  dependencies:
+    - build:fedora_hpx
+  variables:
+    DISTRO: "fedora"
+  allow_failure: true
+
+test:fedora_hpx_clang:
+  extends: test:fedora_hpx
+  dependencies:
+    - build:fedora_hpx_clang
+
+test:fedora_mpi.ignoreNoCI:
+  extends: test:fedora_mpi
+  dependencies:
+    - build:fedora_mpi
+  variables:
+    IGNORE_NOCI: "TRUE"
+  allow_failure: true
+
+test:fedora_legion.ignoreNoCI:
+  extends: test:fedora_legion
+  dependencies:
+    - build:fedora_legion
+  variables:
+    IGNORE_NOCI: "TRUE"
+  allow_failure: true
+
+test:fedora_hpx.ignoreNoCI:
+  extends: test:fedora_hpx
+  dependencies:
+    - build:fedora_hpx
+  variables:
+    IGNORE_NOCI: "TRUE"
+  allow_failure: true
+
+###############
+# Format Jobs #
+###############
+
+format:fedora_mpi:
+  extends: .format
+  dependencies:
+    - build:fedora_mpi
+  variables:
+    DISTRO: "fedora"
+
+format:fedora_legion:
+  extends: .format
+  dependencies:
+    - build:fedora_legion
+  variables:
+    DISTRO: "fedora"
+
+format:fedora_hpx:
+  extends: .format
+  dependencies:
+    - build:fedora_hpx
+  variables:
+    DISTRO: "fedora"
+  allow_failure: true
+
+###############
+###############
+###############

--- a/flecsi/io/simple_definition.h
+++ b/flecsi/io/simple_definition.h
@@ -8,11 +8,11 @@
 #include <flecsi/topology/mesh_definition.h>
 
 #include <fstream>
-#include <string>
 #include <iterator>
 #include <sstream>
-#include <vector>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 #include <flecsi/utils/logging.h>
 
@@ -77,8 +77,8 @@ public:
   /// return the set of vertices that make up all cells
   /// \param [in] from_dim the entity dimension to query
   /// \param [in] to_dim the dimension of entities we wish to return
-  std::vector<std::vector<size_t>>
-  entities(size_t from_dim, size_t to_dim) const override {
+  std::vector<std::vector<size_t>> entities(size_t from_dim,
+    size_t to_dim) const override {
     clog_assert(from_dim == 2, "invalid dimension " << from_dim);
     clog_assert(to_dim == 0, "invalid dimension " << to_dim);
 
@@ -87,11 +87,11 @@ public:
 
     // Go to the start of the cells.
     file_.seekg(cell_start_);
-    for (size_t l(0); l < num_cells_; ++l) {
+    for(size_t l(0); l < num_cells_; ++l) {
       std::getline(file_, line);
       std::istringstream iss(line);
-      ids.push_back(std::vector<size_t>(std::istream_iterator<size_t>(iss),
-                                        std::istream_iterator<size_t>()));
+      ids.push_back(std::vector<size_t>(
+        std::istream_iterator<size_t>(iss), std::istream_iterator<size_t>()));
     }
 
     return ids;

--- a/flecsi/io/simple_definition.h
+++ b/flecsi/io/simple_definition.h
@@ -9,6 +9,9 @@
 
 #include <fstream>
 #include <string>
+#include <iterator>
+#include <sstream>
+#include <vector>
 #include <unordered_map>
 
 #include <flecsi/utils/logging.h>
@@ -24,7 +27,7 @@ namespace io {
 ///
 /// \class simple_definition_t simple_definition.h
 /// \brief simple_definition_t provides a very basic implementation of
-///        the mesh_definition_t interface.
+///        the mesh_definition_u interface.
 ///
 class simple_definition_t : public topology::mesh_definition_u<2>
 {
@@ -70,6 +73,27 @@ public:
   size_t num_entities(size_t dimension) const override {
     return dimension == 0 ? num_vertices_ : num_cells_;
   } // num_entities
+
+  /// return the set of vertices that make up all cells
+  /// \param [in] from_dim the entity dimension to query
+  /// \param [in] to_dim the dimension of entities we wish to return
+  std::vector<std::vector<size_t>>
+  entities(size_t from_dim, size_t to_dim) const override {
+    clog_assert(from_dim == 2, "invalid dimension " << from_dim);
+    clog_assert(to_dim == 0, "invalid dimension " << to_dim);
+
+    std::string line;
+    std::vector<std::vector<size_t>> ids;
+
+    // Go to the start of the cells.
+    file_.seekg(cell_start_);
+    for (size_t l(0); l < num_cells_; ++l) {
+      std::getline(file_, line);
+      std::istringstream iss(line);
+      ids.push_back(std::vector<size_t>(std::istream_iterator<size_t>(iss),
+                                        std::istream_iterator<size_t>()));
+    }
+  }
 
   /// return the set of vertices of a particular entity.
   /// \param [in] dimension  the entity dimension to query.

--- a/flecsi/io/simple_definition.h
+++ b/flecsi/io/simple_definition.h
@@ -93,6 +93,8 @@ public:
       ids.push_back(std::vector<size_t>(std::istream_iterator<size_t>(iss),
                                         std::istream_iterator<size_t>()));
     }
+
+    return ids;
   }
 
   /// return the set of vertices of a particular entity.

--- a/flecsi/supplemental/mesh/empty_mesh_2d.h
+++ b/flecsi/supplemental/mesh/empty_mesh_2d.h
@@ -21,60 +21,50 @@
 namespace flecsi {
 namespace supplemental {
 
-  class vertex : public topology::mesh_entity_u<0, 1>{
-  public:
-    template<size_t M>
-    uint64_t precedence() const { return 0; }
-    vertex() = default;
+class vertex : public topology::mesh_entity_u<0, 1>
+{
+public:
+  vertex() = default;
+};
 
-  };
+class cell : public topology::mesh_entity_u<2, 1>
+{
+public:
+  using id_t = flecsi::utils::id_t;
 
-  class cell : public topology::mesh_entity_u<2, 1>{
-  public:
+  std::vector<size_t> create_entities(id_t cell_id,
+    size_t dim,
+    topology::domain_connectivity_u<2> & c,
+    id_t * e) {
+    return {2, 2, 2, 2};
+  }
+};
 
-    using id_t = flecsi::utils::id_t;
+class empty_mesh_types_t
+{
+public:
+  static constexpr size_t num_dimensions = 2;
 
-    std::vector<size_t>
-    create_entities(id_t cell_id, size_t dim,
-                    topology::domain_connectivity_u<2> & c, id_t * e){
-      return {2, 2, 2, 2};
-    }
+  static constexpr size_t num_domains = 1;
 
-  };
-
-  class empty_mesh_types_t{
-  public:
-    static constexpr size_t num_dimensions = 2;
-
-    static constexpr size_t num_domains = 1;
-
-    using entity_types = std::tuple<
+  using entity_types = std::tuple<
       std::tuple<topology::index_space_<0>, topology::domain_<0>, cell>/*
       std::tuple<topology::index_space_<1>, topology::domain_<0>, vertex>*/>;
 
-    using connectivities = std::tuple<>;
+  using connectivities = std::tuple<>;
 
-    using bindings = std::tuple<>;
+  using bindings = std::tuple<>;
 
-    template<size_t M, size_t D, typename ST>
-    static topology::mesh_entity_base_u<num_domains>*
-    create_entity(topology::mesh_topology_base_u<ST>* mesh,
-                  size_t num_vertices){
-      switch(M){
-        case 0:{
-          switch(D){
-            default:
-              assert(false && "invalid topological dimension");
-          }
-          break;
-        }
-        default:
-          assert(false && "invalid domain");
-      }
-    }
-  };
+  template<size_t M, size_t D, typename ST>
+  static topology::mesh_entity_base_u<num_domains> * create_entity(
+    topology::mesh_topology_base_u<ST> * mesh,
+    size_t num_vertices) {
+    clog_fatal("Should not get here!");
+    return nullptr;
+  }
+};
 
-  using empty_mesh_t = topology::mesh_topology_u<empty_mesh_types_t>;
-  using empty_mesh_2d_t = topology::mesh_topology_u<empty_mesh_types_t>;
+using empty_mesh_t = topology::mesh_topology_u<empty_mesh_types_t>;
+using empty_mesh_2d_t = topology::mesh_topology_u<empty_mesh_types_t>;
 } // namespace supplemental
 } // namespace flecsi

--- a/flecsi/topology/mesh_definition.h
+++ b/flecsi/topology/mesh_definition.h
@@ -85,8 +85,8 @@ public:
   //! @param to_dimension   The dimension of the entities of the definition.
   //--------------------------------------------------------------------------//
 
-  virtual std::vector<std::vector<size_t>>
-  entities(size_t from_dimension, size_t to_dimension) const = 0;
+  virtual std::vector<std::vector<size_t>> entities(size_t from_dimension,
+    size_t to_dimension) const = 0;
 
   //--------------------------------------------------------------------------//
   //! Abstract interface to get the entities of dimension \em to that define

--- a/flecsi/topology/mesh_definition.h
+++ b/flecsi/topology/mesh_definition.h
@@ -78,6 +78,18 @@ public:
 
   //--------------------------------------------------------------------------//
   //! Abstract interface to get the entities of dimension \em to that define
+  //! the entity of dimension \em from.
+  //!
+  //! @param from_dimension The dimension of the entity for which the
+  //!                       definition is being requested.
+  //! @param to_dimension   The dimension of the entities of the definition.
+  //--------------------------------------------------------------------------//
+
+  virtual std::vector<std::vector<size_t>>
+  entities(size_t from_dimension, size_t to_dimension) const = 0;
+
+  //--------------------------------------------------------------------------//
+  //! Abstract interface to get the entities of dimension \em to that define
   //! the entity of dimension \em from with the given identifier \em id.
   //!
   //! @param from_dimension The dimension of the entity for which the

--- a/flecsi/topology/test/test_definition.h
+++ b/flecsi/topology/test/test_definition.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include<vector>
+#include <vector>
 
 #include <flecsi/geometry/point.h>
 #include <flecsi/utils/logging.h>
@@ -79,18 +79,17 @@ public:
     return ids;
   } // vertices
 
-  std::vector<std::vector<size_t>> entities(
-      size_t from_dim,
-      size_t to_dim) const override {
+  std::vector<std::vector<size_t>> entities(size_t from_dim,
+    size_t to_dim) const override {
     assert(from_dim == 2);
     assert(to_dim == 0);
     std::vector<std::vector<size_t>> ids(num_entities(2));
 
-    for (size_t c(0); c < num_entities(2); ++c)
+    for(size_t c(0); c < num_entities(2); ++c)
       ids.push_back(std::vector<size_t>(cells_[c], cells_[c] + 4));
 
     return ids;
-  }  // entities
+  } // entities
 
   point_t vertex(size_t vertex_id) const {
     return point_t(vertices_[vertex_id][0], vertices_[vertex_id][1]);

--- a/flecsi/topology/test/test_definition.h
+++ b/flecsi/topology/test/test_definition.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include<vector>
+
 #include <flecsi/geometry/point.h>
 #include <flecsi/utils/logging.h>
 
@@ -76,6 +78,19 @@ public:
 
     return ids;
   } // vertices
+
+  std::vector<std::vector<size_t>> entities(
+      size_t from_dim,
+      size_t to_dim) const override {
+    assert(from_dim == 2);
+    assert(to_dim == 0);
+    std::vector<std::vector<size_t>> ids(num_entities(2));
+
+    for (size_t c(0); c < num_entities(2); ++c)
+      ids.push_back(std::vector<size_t>(cells_[c], cells_[c] + 4));
+
+    return ids;
+  }  // entities
 
   point_t vertex(size_t vertex_id) const {
     return point_t(vertices_[vertex_id][0], vertices_[vertex_id][1]);


### PR DESCRIPTION
Added virtual method that is used by flecsi-sp.  This will enable casting different mesh definitions to the base class where needed in flecsi-sp.

After this gets accepted, I'll create an analogous change for master branch and issue a new PR.

Partially closes #508