### PR TITLE
Updated Boost Linkage to Modern Targets

### DIFF
--- a/config/project.cmake
+++ b/config/project.cmake
@@ -266,7 +266,7 @@ endif()
 #------------------------------------------------------------------------------#
 
 if(ENABLE_BOOST)
-  list(APPEND FLECSI_LIBRARY_DEPENDENCIES ${Boost_LIBRARIES})
+  list(APPEND FLECSI_LIBRARY_DEPENDENCIES Boost::program_options)
 endif()
 
 #------------------------------------------------------------------------------#


### PR DESCRIPTION
Updated Boost linkage in CMake to use more modern imported targets
(Documented as part of FindBoost as of CMake 3.5.2. Provided by Boost
install's cmake targets otherwise)

This resolves the issue where CMake may find the desired Boost install
by specifying BOOST_DIR but only provide -lboost_program_options-mt at
the link line. This results in undefined behavior where the system Boost
may take priority and cause linking errors.
By using the more modern imported targets CMake will provide the full
path to the desired library and ensure that the correct version of Boost
is linked to.