### PR TITLE
Template-based task and field registration

### DIFF
--- a/flecsi/data/common/field_info.hh
+++ b/flecsi/data/common/field_info.hh
@@ -39,7 +39,6 @@ namespace data {
 struct field_info_t {
   size_t key = std::numeric_limits<size_t>::max();
   field_id_t fid = FIELD_ID_MAX;
-  size_t index_space = std::numeric_limits<size_t>::max();
   size_t type_size = std::numeric_limits<size_t>::max();
 }; // struct field_info_t
 
@@ -58,7 +57,6 @@ struct field_info_store_t {
     flog(internal) << "Registering field info" << std::endl
                    << "\tkey: " << fi.key << std::endl
                    << "\tfid: " << fi.fid << std::endl
-                   << "\tindex_space: " << fi.index_space << std::endl
                    << "\ttype_size: " << fi.type_size << std::endl;
     data_.emplace_back(fi);
     const size_t offset = data_.size() - 1;

--- a/flecsi/data/common/field_info.hh
+++ b/flecsi/data/common/field_info.hh
@@ -62,7 +62,6 @@ struct field_info_store_t {
                    << "\ttype_size: " << fi.type_size << std::endl;
     data_.emplace_back(fi);
     const size_t offset = data_.size() - 1;
-    fid_lookup_[fi.fid] = offset;
     key_lookup_[fi.key] = offset;
   } // add_field_info
 
@@ -125,7 +124,6 @@ struct field_info_store_t {
 
 private:
   std::vector<field_info_t> data_;
-  std::unordered_map<size_t, size_t> fid_lookup_;
   std::unordered_map<size_t, size_t> key_lookup_;
 
 }; // struct field_info_store_t

--- a/flecsi/data/common/field_info.hh
+++ b/flecsi/data/common/field_info.hh
@@ -37,12 +37,9 @@ namespace data {
  */
 
 struct field_info_t {
-  size_t namespace_hash = std::numeric_limits<size_t>::max();
-  size_t name_hash = std::numeric_limits<size_t>::max();
   size_t key = std::numeric_limits<size_t>::max();
   field_id_t fid = FIELD_ID_MAX;
   size_t index_space = std::numeric_limits<size_t>::max();
-  size_t versions = std::numeric_limits<size_t>::max();
   size_t type_size = std::numeric_limits<size_t>::max();
 }; // struct field_info_t
 
@@ -59,12 +56,9 @@ struct field_info_store_t {
 
   void add_field_info(field_info_t const & fi) {
     flog(internal) << "Registering field info" << std::endl
-                   << "\tnamespace_hash: " << fi.namespace_hash << std::endl
-                   << "\tname_hash: " << fi.name_hash << std::endl
                    << "\tkey: " << fi.key << std::endl
                    << "\tfid: " << fi.fid << std::endl
                    << "\tindex_space: " << fi.index_space << std::endl
-                   << "\tversions: " << fi.versions << std::endl
                    << "\ttype_size: " << fi.type_size << std::endl;
     data_.emplace_back(fi);
     const size_t offset = data_.size() - 1;

--- a/flecsi/data/common/field_info.hh
+++ b/flecsi/data/common/field_info.hh
@@ -37,7 +37,6 @@ namespace data {
  */
 
 struct field_info_t {
-  size_t key = std::numeric_limits<size_t>::max();
   field_id_t fid = FIELD_ID_MAX;
   size_t type_size = std::numeric_limits<size_t>::max();
 }; // struct field_info_t
@@ -53,14 +52,14 @@ struct field_info_t {
 
 struct field_info_store_t {
 
-  void add_field_info(field_info_t const & fi) {
+  void add_field_info(field_info_t const & fi,std::size_t key) {
     flog(internal) << "Registering field info" << std::endl
-                   << "\tkey: " << fi.key << std::endl
+                   << "\tkey: " << key << std::endl
                    << "\tfid: " << fi.fid << std::endl
                    << "\ttype_size: " << fi.type_size << std::endl;
     data_.emplace_back(fi);
     const size_t offset = data_.size() - 1;
-    key_lookup_[fi.key] = offset;
+    key_lookup_[key] = offset;
   } // add_field_info
 
   /*!

--- a/flecsi/data/common/storage_class.hh
+++ b/flecsi/data/common/storage_class.hh
@@ -62,7 +62,7 @@ struct storage_class_u {
 
   using topology_reference_t = topology_reference_u<TOPOLOGY_TYPE>;
 
-  template<typename DATA_TYPE, size_t NAMESPACE, size_t NAME, size_t VERSION>
+  template<size_t NAMESPACE, size_t NAME, size_t VERSION>
   static field_reference_t get_reference(
     topology_reference_t const & topology) {
     constexpr size_t identifier =

--- a/flecsi/data/data.hh
+++ b/flecsi/data/data.hh
@@ -100,7 +100,7 @@
  */
 
 #define flecsi_add_field(                                                      \
-  topology_type, nspace, name, data_type, storage_class, versions, ...)        \
+  topology_type, nspace, name, data_type, storage_class, versions)             \
   /* MACRO IMPLEMENTATION */                                                   \
                                                                                \
   /* Call the storage policy to register the data */                           \
@@ -110,8 +110,7 @@
       data_type,                                                               \
       flecsi_internal_string_hash(nspace),                                     \
       flecsi_internal_string_hash(name),                                       \
-      versions,                                                                \
-      ##__VA_ARGS__>({flecsi_internal_stringify(name)})
+      versions>({flecsi_internal_stringify(name)})
 
 /*!
   @def flecsi_field_instance
@@ -171,7 +170,7 @@
   /* MACRO IMPLEMENTATION */                                                   \
                                                                                \
   flecsi_add_field(::flecsi::topology::global_topology_t,nspace,name,          \
-    data_type,global,versions,::flecsi::topology::global_index_space)
+    data_type,global,versions)
 
 /*!
   @def flecsi_global_field_instance
@@ -228,7 +227,7 @@
   /* MACRO IMPLEMENTATION */                                                   \
                                                                                \
   flecsi_add_field(::flecsi::topology::index_topology_t,nspace,name,           \
-    data_type,index,versions,::flecsi::topology::index_index_space)
+    data_type,index,versions)
 
 /*!
   @def flecsi_index_field_instance

--- a/flecsi/data/data.hh
+++ b/flecsi/data/data.hh
@@ -121,7 +121,6 @@
                        the data.
   @param nspace        The string namespace to use to access the variable.
   @param name          The string name of the data variable to access.
-  @param data_type     The data type to access, e.g., double or my_type_t.
   @param storage_class The storage type for the data \ref storage_class_t.
   @param version       The version number of the data to access. This
                        parameter can be used to manage multiple data versions,
@@ -131,14 +130,13 @@
  */
 
 #define flecsi_field_instance(                                                 \
-  topology, nspace, name, data_type, storage_class, version)                   \
+  topology, nspace, name, storage_class, version)                              \
   /* MACRO IMPLEMENTATION */                                                   \
                                                                                \
   /* Call the storage policy to get a handle to the data */                    \
   flecsi::data::field_interface_t::field_instance<decltype(                    \
                                                     topology)::topology_t,     \
     flecsi::data::storage_class,                                               \
-    data_type,                                                                 \
     flecsi_internal_string_hash(nspace),                                       \
     flecsi_internal_string_hash(name),                                         \
     version>(topology)
@@ -179,7 +177,6 @@
 
   @param nspace        The string namespace to use to access the variable.
   @param name          The string of the data variable to access.
-  @param data_type     The data type to access, e.g., double or my_type_t.
   @param storage_class The storage type for the data \ref storage_class_t.
   @param version       The version number of the data to access. This
                        parameter can be used to manage multiple data versions,
@@ -188,7 +185,7 @@
   @ingroup data
  */
 
-#define flecsi_global_field_instance(nspace, name, data_type, version)         \
+#define flecsi_global_field_instance(nspace, name, version)                    \
   /* MACRO IMPLEMENTATION */                                                   \
                                                                                \
   /* WARNING: This macro returns a handle. Don't add terminations! */          \
@@ -197,7 +194,6 @@
       flecsi::topology::global_topology_t, "internal", "global_topology"),     \
     nspace,                                                                    \
     name,                                                                      \
-    data_type,                                                                 \
     global,                                                                    \
     version)
 
@@ -236,7 +232,6 @@
 
   @param nspace        The string namespace to use to access the variable.
   @param name          The string of the data variable to access.
-  @param data_type     The data type to access, e.g., double or my_type_t.
   @param storage_class The storage type for the data \ref storage_class_t.
   @param version       The version number of the data to access. This
                        parameter can be used to manage multiple data versions,
@@ -245,7 +240,7 @@
   @ingroup data
  */
 
-#define flecsi_index_field_instance(nspace, name, data_type, version)          \
+#define flecsi_index_field_instance(nspace, name, version)                     \
   /* MACRO IMPLEMENTATION */                                                   \
                                                                                \
   /* WARNING: This macro returns a handle. Don't add terminations! */          \
@@ -254,6 +249,5 @@
       flecsi::topology::index_topology_t, "internal", "index_topology"),       \
     nspace,                                                                    \
     name,                                                                      \
-    data_type,                                                                 \
     index,                                                                     \
     version)

--- a/flecsi/data/data.hh
+++ b/flecsi/data/data.hh
@@ -170,6 +170,11 @@
   flecsi_add_field(::flecsi::topology::global_topology_t,nspace,name,          \
     data_type,global,versions)
 
+/// The global topology.
+#define flecsi_global_topology                                    \
+  flecsi_topology_reference(flecsi::topology::global_topology_t,  \
+                            "internal","global_topology")
+
 /*!
   @def flecsi_global_field_instance
 
@@ -190,8 +195,7 @@
                                                                                \
   /* WARNING: This macro returns a handle. Don't add terminations! */          \
   flecsi_field_instance(                                                       \
-    flecsi_topology_reference(                                                 \
-      flecsi::topology::global_topology_t, "internal", "global_topology"),     \
+    flecsi_global_topology,                                                    \
     nspace,                                                                    \
     name,                                                                      \
     global,                                                                    \
@@ -225,6 +229,11 @@
   flecsi_add_field(::flecsi::topology::index_topology_t,nspace,name,           \
     data_type,index,versions)
 
+/// The default index topology.
+#define flecsi_index_topology                                   \
+  flecsi_topology_reference(flecsi::topology::index_topology_t, \
+                            "internal","index_topology")
+
 /*!
   @def flecsi_index_field_instance
 
@@ -245,8 +254,7 @@
                                                                                \
   /* WARNING: This macro returns a handle. Don't add terminations! */          \
   flecsi_field_instance(                                                       \
-    flecsi_topology_reference(                                                 \
-      flecsi::topology::index_topology_t, "internal", "index_topology"),       \
+    flecsi_index_topology,                                                     \
     nspace,                                                                    \
     name,                                                                      \
     index,                                                                     \

--- a/flecsi/data/data.hh
+++ b/flecsi/data/data.hh
@@ -170,16 +170,8 @@
 #define flecsi_add_global_field(nspace, name, data_type, versions)             \
   /* MACRO IMPLEMENTATION */                                                   \
                                                                                \
-  /* Call the storage policy to register the data */                           \
-  inline bool flecsi_internal_unique_name(global_field) =                      \
-    flecsi::data::field_interface_t::add_field<                                \
-      flecsi::topology::global_topology_t,                                     \
-      flecsi::data::global,                                                    \
-      data_type,                                                               \
-      flecsi_internal_string_hash(nspace),                                     \
-      flecsi_internal_string_hash(name),                                       \
-      versions,                                                                \
-      flecsi::topology::global_index_space>({flecsi_internal_stringify(name)})
+  flecsi_add_field(::flecsi::topology::global_topology_t,nspace,name,          \
+    data_type,global,versions,::flecsi::topology::global_index_space)
 
 /*!
   @def flecsi_global_field_instance
@@ -235,16 +227,8 @@
 #define flecsi_add_index_field(nspace, name, data_type, versions)              \
   /* MACRO IMPLEMENTATION */                                                   \
                                                                                \
-  /* Call the storage policy to register the data */                           \
-  inline bool flecsi_internal_unique_name(index_field) =                       \
-    flecsi::data::field_interface_t::add_field<                                \
-      flecsi::topology::index_topology_t,                                      \
-      flecsi::data::index,                                                     \
-      data_type,                                                               \
-      flecsi_internal_string_hash(nspace),                                     \
-      flecsi_internal_string_hash(name),                                       \
-      versions,                                                                \
-      flecsi::topology::index_index_space>({flecsi_internal_stringify(name)})
+  flecsi_add_field(::flecsi::topology::index_topology_t,nspace,name,           \
+    data_type,index,versions,::flecsi::topology::index_index_space)
 
 /*!
   @def flecsi_index_field_instance

--- a/flecsi/data/field_interface.hh
+++ b/flecsi/data/field_interface.hh
@@ -61,7 +61,6 @@ struct field_interface_u {
     @tparam NAME          The attribute name.
     @tparam VERSIONS      The number of versions that shall be associated
                           with this attribute.
-    @tparam INDEX_SPACE   The index space identifier.
 
     @param name The string version of the field name.
 
@@ -73,8 +72,7 @@ struct field_interface_u {
     typename DATA_TYPE,
     size_t NAMESPACE,
     size_t NAME,
-    size_t VERSIONS,
-    size_t INDEX_SPACE = 0>
+    size_t VERSIONS>
   static bool add_field(std::string const & name) {
     static_assert(VERSIONS <= utils::hash::field_max_versions,
       "max field versions exceeded");
@@ -82,7 +80,6 @@ struct field_interface_u {
     field_info_t fi;
 
     fi.type_size = sizeof(DATA_TYPE);
-    fi.index_space = INDEX_SPACE;
 
     flog(internal) << "Registering field" << std::endl
                    << "\tname: " << name << std::endl
@@ -113,7 +110,6 @@ struct field_interface_u {
     @tparam NAMESPACE     The namespace key. Namespaces allow separation
                           of attribute names to avoid collisions.
     @tparam NAME          The attribute name.
-    @tparam INDEX_SPACE   The index space identifier.
     @tparam VERSION       The data version.
 
     @ingroup data
@@ -153,7 +149,6 @@ struct field_interface_u {
     @tparam NAMESPACE     The namespace key. Namespaces allow separation
                           of attribute names to avoid collisions.
     @tparam NAME          The attribute name.
-    @tparam INDEX_SPACE   The index space identifier.
     @tparam VERSION       The data version.
 
     @ingroup data

--- a/flecsi/data/field_interface.hh
+++ b/flecsi/data/field_interface.hh
@@ -88,10 +88,10 @@ struct field_interface_u {
 
     for(size_t version(0); version < VERSIONS; ++version) {
       fi.fid = unique_fid_t::instance().next();
-      fi.key = utils::hash::field_hash<NAMESPACE, NAME>(version);
 
       execution::context_t::instance().add_field_info(
-        TOPOLOGY_TYPE::type_identifier_hash, STORAGE_CLASS, fi);
+        TOPOLOGY_TYPE::type_identifier_hash, STORAGE_CLASS, fi,
+        utils::hash::field_hash<NAMESPACE,NAME>(version));
     } // for
 
     return true;

--- a/flecsi/data/field_interface.hh
+++ b/flecsi/data/field_interface.hh
@@ -81,10 +81,7 @@ struct field_interface_u {
 
     field_info_t fi;
 
-    fi.namespace_hash = NAMESPACE;
-    fi.name_hash = NAME;
     fi.type_size = sizeof(DATA_TYPE);
-    fi.versions = VERSIONS;
     fi.index_space = INDEX_SPACE;
 
     flog(internal) << "Registering field" << std::endl

--- a/flecsi/data/field_interface.hh
+++ b/flecsi/data/field_interface.hh
@@ -117,7 +117,6 @@ struct field_interface_u {
 
   template<typename TOPOLOGY_TYPE,
     size_t STORAGE_CLASS,
-    typename DATA_TYPE,
     size_t NAMESPACE,
     size_t NAME,
     size_t VERSION = 0>
@@ -132,7 +131,7 @@ struct field_interface_u {
         TOPOLOGY_TYPE>;
 
     return storage_class_t::
-      template get_reference<DATA_TYPE, NAMESPACE, NAME, VERSION>(
+      template get_reference<NAMESPACE, NAME, VERSION>(
         topology_reference);
   } // field_instance
 

--- a/flecsi/data/test/global.cc
+++ b/flecsi/data/test/global.cc
@@ -20,8 +20,10 @@
 
 using namespace flecsi;
 
-flecsi_add_global_field("test", "global", double, 2);
-inline auto th = flecsi_global_field_instance("test", "global", 0);
+namespace {
+  const data::field_interface_t::global_field<double> gfld(2);
+  const auto th=gfld(flecsi_global_topology);
+}
 
 template<size_t PRIVILEGES>
 using global_accessor_u =

--- a/flecsi/data/test/global.cc
+++ b/flecsi/data/test/global.cc
@@ -21,7 +21,7 @@
 using namespace flecsi;
 
 flecsi_add_global_field("test", "global", double, 2);
-inline auto th = flecsi_global_field_instance("test", "global", double, 0);
+inline auto th = flecsi_global_field_instance("test", "global", 0);
 
 template<size_t PRIVILEGES>
 using global_accessor_u =

--- a/flecsi/data/test/index.cc
+++ b/flecsi/data/test/index.cc
@@ -21,7 +21,7 @@
 using namespace flecsi;
 
 flecsi_add_index_field("test", "value", double, 2);
-inline auto fh = flecsi_index_field_instance("test", "value", double, 0);
+inline auto fh = flecsi_index_field_instance("test", "value", 0);
 
 template<size_t PRIVILEGES>
 using accessor =

--- a/flecsi/data/test/index.cc
+++ b/flecsi/data/test/index.cc
@@ -20,8 +20,10 @@
 
 using namespace flecsi;
 
-flecsi_add_index_field("test", "value", double, 2);
-inline auto fh = flecsi_index_field_instance("test", "value", 0);
+namespace {
+  const data::field_interface_t::field<double> ifld(2);
+  const auto fh=ifld(flecsi_index_topology);
+}
 
 template<size_t PRIVILEGES>
 using accessor =

--- a/flecsi/execution/context.hh
+++ b/flecsi/execution/context.hh
@@ -398,13 +398,14 @@ struct context_u : public CONTEXT_POLICY {
 
   void add_field_info(size_t topology_type_identifier,
     size_t storage_class,
-    const data::field_info_t & field_info) {
+    const data::field_info_t & field_info,
+    std::size_t key) {
     flog(internal) << "Registering field info (context)" << std::endl
                    << "\ttopology type identifier: " << topology_type_identifier
                    << std::endl
                    << "\tstorage class: " << storage_class << std::endl;
     topology_field_info_map_[topology_type_identifier][storage_class]
-      .add_field_info(field_info);
+      .add_field_info(field_info,key);
   } // add_field_information
 
   /*!

--- a/flecsi/execution/internal.hh
+++ b/flecsi/execution/internal.hh
@@ -34,9 +34,9 @@
                                                                                \
   /* Execute the user task */                                                  \
   /* WARNING: This macro returns a future. Don't add terminations! */          \
-  flecsi::execution::task_interface_t::execute_task<flecsi_internal_hash(      \
-                                                      task),                   \
+  flecsi::execution::task_interface_t::execute_task<                           \
     flecsi_internal_hash(domain),                                              \
     flecsi_internal_hash(operation),                                           \
     flecsi_internal_return_type(task),                                         \
-    flecsi_internal_arguments_type(task)>(__VA_ARGS__)
+    flecsi_internal_arguments_type(task)>(flecsi_internal_hash(task),          \
+      ##__VA_ARGS__)

--- a/flecsi/execution/legion/context_policy.hh
+++ b/flecsi/execution/legion/context_policy.hh
@@ -399,6 +399,7 @@ struct legion_context_policy_t {
     flog_assert(task_registry_.find(key) == task_registry_.end(),
       "task key already exists");
 
+    // FIXME: can we just re-use "key" (at least if it's reduced to 32 bits)?
     task_registry_[key] = std::make_tuple(
       unique_tid_t::instance().next(), processor, execution, name, callback);
 

--- a/flecsi/execution/legion/enactment/task_wrapper.hh
+++ b/flecsi/execution/legion/enactment/task_wrapper.hh
@@ -127,12 +127,11 @@ struct pure_task_wrapper_u {
  @tparam RETURN    The return type of the user task.
  @tparam ARG_TUPLE A std::tuple of the user task arguments.
  @tparam DELEGATE  The delegate function that invokes the user task.
- @tparam KEY       A hash key identifying the task.
 
  @ingroup legion-execution
  */
 
-template<size_t KEY,
+template<
   typename RETURN,
   typename ARG_TUPLE,
   RETURN (*DELEGATE)(ARG_TUPLE)>

--- a/flecsi/execution/legion/execution_policy.hh
+++ b/flecsi/execution/legion/execution_policy.hh
@@ -104,11 +104,11 @@ struct legion_execution_policy_t {
     Documentation for this interface is in the top-level context type.
    */
 
-  template<size_t TASK,
+  template<
     typename RETURN,
     typename ARG_TUPLE,
     RETURN (*DELEGATE)(ARG_TUPLE)>
-  static bool register_task(processor_type_t processor,
+  static bool register_task(std::size_t TASK,processor_type_t processor,
     task_execution_type_t execution,
     std::string name) {
 
@@ -126,13 +126,13 @@ struct legion_execution_policy_t {
     Documentation for this interface is in the top-level context type.
    */
 
-  template<size_t TASK,
+  template<
     size_t LAUNCH_DOMAIN,
     size_t REDUCTION,
     typename RETURN,
     typename ARG_TUPLE,
     typename... ARGS>
-  static decltype(auto) execute_task(ARGS &&... args) {
+  static decltype(auto) execute_task(std::size_t TASK,ARGS &&... args) {
 
     using namespace Legion;
 
@@ -146,7 +146,7 @@ struct legion_execution_policy_t {
     context_t & flecsi_context = context_t::instance();
 
     // Get the processor type.
-    auto processor_type = flecsi_context.processor_type<TASK>();
+    auto processor_type = flecsi_context.processor_type(TASK);
 
     // Get the Legion runtime and context from the current task.
     auto legion_runtime = Legion::Runtime::get_runtime();
@@ -176,7 +176,7 @@ struct legion_execution_policy_t {
         flog(internal) << "Executing single task" << std::endl;
       }
 
-      TaskLauncher launcher(flecsi_context.task_id<TASK>(),
+      TaskLauncher launcher(flecsi_context.task_id(TASK),
         TaskArgument(&task_args, sizeof(ARG_TUPLE)));
 
       for(auto & req : init_args.region_requirements()) {
@@ -232,7 +232,7 @@ struct legion_execution_policy_t {
       Domain launch_domain = Domain::from_rect<1>(launch_bounds);
 
       Legion::ArgumentMap arg_map;
-      Legion::IndexLauncher launcher(flecsi_context.task_id<TASK>(),
+      Legion::IndexLauncher launcher(flecsi_context.task_id(TASK),
         launch_domain,
         TaskArgument(&task_args, sizeof(ARG_TUPLE)),
         arg_map);

--- a/flecsi/execution/legion/execution_policy.hh
+++ b/flecsi/execution/legion/execution_policy.hh
@@ -112,7 +112,7 @@ struct legion_execution_policy_t {
     task_execution_type_t execution,
     std::string name) {
 
-    using wrapper_t = legion::task_wrapper_u<TASK, RETURN, ARG_TUPLE, DELEGATE>;
+    using wrapper_t = legion::task_wrapper_u<RETURN, ARG_TUPLE, DELEGATE>;
 
     const bool success = context_t::instance().register_task(
       TASK, processor, execution, name, wrapper_t::registration_callback);

--- a/flecsi/execution/test/task.cc
+++ b/flecsi/execution/test/task.cc
@@ -37,6 +37,12 @@ simple(int value) {
   }
 } // simple
 
+template<class T>
+void simple2(T t) {
+  flog_tag_guard(task);
+  flog(info) << "simple2(" << t << ")\n";
+}
+
 flecsi_register_task(simple, task, loc, index);
 
 } // namespace task
@@ -53,6 +59,8 @@ test_driver(int argc, char ** argv) {
   flecsi_execute_task(simple, task, single, 10);
 
   flecsi_execute_task(simple, task, index, 8);
+
+  task_interface_t::execute<task::simple2<float>>(6.1);
 
   return FTEST_RESULT();
 }

--- a/flecsi/utils/demangle.cc
+++ b/flecsi/utils/demangle.cc
@@ -16,6 +16,8 @@
 
 #include <memory>
 
+#include"demangle.h"
+
 #if defined(__GNUG__)
 #include <cxxabi.h>
 #endif

--- a/flecsi/utils/demangle.hh
+++ b/flecsi/utils/demangle.hh
@@ -15,6 +15,9 @@
 
 /*! @file */
 
+#include<string>
+#include<typeinfo>              // typeid()
+
 namespace flecsi {
 namespace utils {
 

--- a/flecsi/utils/demangle.hh
+++ b/flecsi/utils/demangle.hh
@@ -58,5 +58,17 @@ type(const std::type_info & type_info) {
   return demangle(type_info.name());
 } // type
 
+/// Dummy class template.
+/// \tparam S a reference to a function or variable
+template<auto &S> struct Symbol {};
+/// Return the name of the template argument.
+/// \tparam a reference to a function or variable
+/// \return demangled name
+template<auto &S> std::string symbol() {
+  constexpr int PFX=sizeof("flecsi::utils::Symbol<")-1;
+  const auto s=type<Symbol<S>>();
+  return s.substr(PFX,s.size()-1-PFX);
+}
+
 } // namespace utils
 } // namespace flecsi

--- a/flecsi/utils/function_traits.hh
+++ b/flecsi/utils/function_traits.hh
@@ -19,6 +19,8 @@
 #error Do not include this file directly!
 #endif
 
+#include<tuple>
+
 namespace flecsi {
 namespace utils {
 

--- a/flecsi/utils/test/demangle.cc
+++ b/flecsi/utils/test/demangle.cc
@@ -31,6 +31,13 @@ demangle(int argc, char ** argv) {
   EXPECT_NE(str_type, "");
   EXPECT_EQ(str_demangle, str_type);
 
+  const auto sym=flecsi::utils::symbol<demangle>();
+#ifdef __GNUG__
+  EXPECT_EQ(sym,"demangle(int, char**)");
+#else
+  EXPECT_NE(sym,"");
+#endif
+
   return 0;
 }
 


### PR DESCRIPTION
This adds alternative syntax for registering tasks and fields, including support for tasks that are specializations of function templates.  They may be able to replace `flecsi_register_task`/`flecsi_execute_task` and `flecsi_add_field`/`flecsi_field_instance` (and their global/index variants) entirely; so far, some of the tests are changed to demonstrate (and test) the new interface.

The interface of `execute` may need some work to elegantly handle non-default policies.