### PR TITLE
Single backend (partial)

### DIFF
--- a/flecsi/data/common/storage_class.hh
+++ b/flecsi/data/common/storage_class.hh
@@ -30,10 +30,6 @@
 #include <flecsi/utils/hash.hh>
 #endif
 
-#ifndef POLICY_NAMESPACE
-#error You must define a data policy namespace before including this file.
-#endif
-
 namespace flecsi {
 namespace data {
 
@@ -52,8 +48,6 @@ enum storage_label_t : size_t {
   ragged,
   subspace
 }; // enum storage_label_t
-
-namespace POLICY_NAMESPACE {
 
 /*!
   Base storage class type for topology-specific specializations.
@@ -76,6 +70,5 @@ struct storage_class_u {
 
 }; // struct storage_class_u
 
-} // namespace POLICY_NAMESPACE
 } // namespace data
 } // namespace flecsi

--- a/flecsi/data/common/topology.hh
+++ b/flecsi/data/common/topology.hh
@@ -24,13 +24,8 @@
 #include <flecsi/data/common/data_reference.hh>
 #endif
 
-#ifndef POLICY_NAMESPACE
-#error You must define a data policy namespace before including this file.
-#endif
-
 namespace flecsi {
 namespace data {
-namespace POLICY_NAMESPACE {
 
 #if 0 // FIXME: Remove this
 /*!
@@ -54,6 +49,5 @@ struct topology_u {
 template<typename TOPOLOGY_TYPE>
 struct topology_instance_u {};
 
-} // namespace POLICY_NAMESPACE
 } // namespace data
 } // namespace flecsi

--- a/flecsi/data/field_interface.hh
+++ b/flecsi/data/field_interface.hh
@@ -30,6 +30,7 @@
 #include <flecsi/runtime/types.hh>
 #include <flecsi/utils/common.hh>
 #include <flecsi/utils/hash.hh>
+#include"common/storage_class.hh"
 
 namespace flecsi {
 namespace data {
@@ -181,7 +182,7 @@ struct field_interface_u {
       VERSION < utils::hash::field_max_versions, "max field version exceeded");
 
     using storage_class_t =
-      typename DATA_POLICY::template storage_class_u<STORAGE_CLASS,
+      storage_class_u<STORAGE_CLASS,
         TOPOLOGY_TYPE>;
 
     return storage_class_t::template get_reference<NAMESPACE, NAME, VERSION>(
@@ -220,7 +221,7 @@ struct field_interface_u {
       VERSION < utils::hash::field_max_versions, "max field version exceeded");
 
     using storage_class_t =
-      typename DATA_POLICY::template storage_class_u<STORAGE_CLASS>;
+      storage_class_u<STORAGE_CLASS>;
 
     return storage_class_t::template get_mutator<TOPOLOGY_TYPE, DATA_TYPE,
       NAMESPACE, NAME, VERSION>(client_handle, slots);

--- a/flecsi/data/legion/data_policy.hh
+++ b/flecsi/data/legion/data_policy.hh
@@ -29,18 +29,6 @@ namespace data {
 struct legion_data_policy_t {
 
   /*--------------------------------------------------------------------------*
-    Storage Class Interface.
-   *--------------------------------------------------------------------------*/
-
-  /*
-    Capture the base storage class type. This is necessary as a place holder in
-    the field interface.
-   */
-
-  template<size_t STORAGE_CLASS, typename TOPOLOGY_TYPE>
-  using storage_class_u = storage_class_u<STORAGE_CLASS, TOPOLOGY_TYPE>;
-
-  /*--------------------------------------------------------------------------*
     Topology Instance Interface.
    *--------------------------------------------------------------------------*/
 

--- a/flecsi/data/legion/data_policy.hh
+++ b/flecsi/data/legion/data_policy.hh
@@ -38,14 +38,14 @@ struct legion_data_policy_t {
    */
 
   template<size_t STORAGE_CLASS, typename TOPOLOGY_TYPE>
-  using storage_class_u = legion::storage_class_u<STORAGE_CLASS, TOPOLOGY_TYPE>;
+  using storage_class_u = storage_class_u<STORAGE_CLASS, TOPOLOGY_TYPE>;
 
   /*--------------------------------------------------------------------------*
     Topology Instance Interface.
    *--------------------------------------------------------------------------*/
 
   template<typename TOPOLOGY_TYPE>
-  using topology_instance_u = typename legion::topology_instance_u<
+  using topology_instance_u = topology_instance_u<
     typename TOPOLOGY_TYPE::type_identifier_t>;
 
   template<typename TOPOLOGY_TYPE>

--- a/flecsi/data/legion/storage_classes.hh
+++ b/flecsi/data/legion/storage_classes.hh
@@ -26,10 +26,8 @@
 //#include <flecsi/topology/unstructured_mesh/interface.hh>
 #endif
 
-#define POLICY_NAMESPACE legion
 #include <flecsi/data/common/storage_class.hh>
 #include <flecsi/data/common/topology.hh>
-#undef POLICY_NAMESPACE
 
 namespace flecsi {
 namespace data {

--- a/flecsi/data/legion/topologies.hh
+++ b/flecsi/data/legion/topologies.hh
@@ -19,10 +19,7 @@
 #include <flecsi/execution/context.hh>
 #include <flecsi/runtime/types.hh>
 #include <flecsi/utils/flog.hh>
-
-#define POLICY_NAMESPACE legion
 #include <flecsi/data/common/topology.hh>
-#undef POLICY_NAMESPACE
 
 #if !defined(FLECSI_ENABLE_LEGION)
 #error FLECSI_ENABLE_LEGION not defined! This file depends on Legion!
@@ -58,21 +55,18 @@ class unstructured_mesh_topology_u;
 } // namespace topology
 
 namespace data {
-namespace legion {
-
-using namespace topology;
 
 /*----------------------------------------------------------------------------*
   Index Topology.
  *----------------------------------------------------------------------------*/
 
 template<>
-struct topology_instance_u<index_topology_t> {
+struct topology_instance_u<topology::index_topology_t> {
 
-  using topology_reference_t = topology_reference_u<index_topology_t>;
+  using topology_reference_t = topology_reference_u<topology::index_topology_t>;
 
   static void create(topology_reference_t const & topology_reference,
-    index_topology_t::coloring_t const & coloring) {
+    topology::index_topology_t::coloring_t const & coloring) {
 
     {
       flog_tag_guard(topologies);
@@ -102,7 +96,7 @@ struct topology_instance_u<index_topology_t> {
       legion_runtime->create_field_space(legion_context);
 
     auto & field_info_store = flecsi_context.get_field_info_store(
-      index_topology_t::type_identifier_hash, storage_label_t::index);
+      topology::index_topology_t::type_identifier_hash, storage_label_t::index);
 
     Legion::FieldAllocator allocator = legion_runtime->create_field_allocator(
       legion_context, runtime_data.field_space);
@@ -156,11 +150,12 @@ struct topology_instance_u<index_topology_t> {
  *----------------------------------------------------------------------------*/
 
 template<typename POLICY_TYPE>
-struct topology_instance_u<ntree_topology_u<POLICY_TYPE>> {
+struct topology_instance_u<topology::ntree_topology_u<POLICY_TYPE>> {
 
   using topology_reference_t =
-    topology_reference_u<ntree_topology_u<POLICY_TYPE>>;
-  using coloring_t = typename ntree_topology_u<POLICY_TYPE>::coloring_t;
+    topology_reference_u<topology::ntree_topology_u<POLICY_TYPE>>;
+  using coloring_t =
+		typename topology::ntree_topology_u<POLICY_TYPE>::coloring_t;
 
   static void create(topology_reference_t const & topology_reference,
     coloring_t const & coloring) {}
@@ -174,10 +169,10 @@ struct topology_instance_u<ntree_topology_u<POLICY_TYPE>> {
  *----------------------------------------------------------------------------*/
 
 template<typename POLICY_TYPE>
-struct topology_instance_u<set_topology_u<POLICY_TYPE>> {
+struct topology_instance_u<topology::set_topology_u<POLICY_TYPE>> {
 
   using topology_reference_t =
-    topology_reference_u<set_topology_u<POLICY_TYPE>>;
+    topology_reference_u<topology::set_topology_u<POLICY_TYPE>>;
 
 }; // set_topology_u specialization
 
@@ -186,10 +181,10 @@ struct topology_instance_u<set_topology_u<POLICY_TYPE>> {
  *----------------------------------------------------------------------------*/
 
 template<typename POLICY_TYPE>
-struct topology_instance_u<structured_mesh_topology_u<POLICY_TYPE>> {
+struct topology_instance_u<topology::structured_mesh_topology_u<POLICY_TYPE>> {
 
   using topology_reference_t =
-    topology_reference_u<structured_mesh_topology_u<POLICY_TYPE>>;
+    topology_reference_u<topology::structured_mesh_topology_u<POLICY_TYPE>>;
 
 }; // structured_mesh_topology_u specialization
 
@@ -198,10 +193,11 @@ struct topology_instance_u<structured_mesh_topology_u<POLICY_TYPE>> {
  *----------------------------------------------------------------------------*/
 
 template<typename POLICY_TYPE>
-struct topology_instance_u<unstructured_mesh_topology_u<POLICY_TYPE>> {
+struct topology_instance_u<topology::unstructured_mesh_topology_u<POLICY_TYPE>>
+{
 
   using topology_reference_t =
-    topology_reference_u<unstructured_mesh_topology_u<POLICY_TYPE>>;
+    topology_reference_u<topology::unstructured_mesh_topology_u<POLICY_TYPE>>;
 
 }; // unstructured_mesh_topology_u specialization
 
@@ -223,6 +219,5 @@ struct client_handle_specialization_u<topology::mesh_topology_t<MESH_POLICY>> {
 }; // client_handle_specialization_u<topology::mesh_topology_t<MESH_POLICY>>
 #endif
 
-} // namespace legion
 } // namespace data
 } // namespace flecsi

--- a/flecsi/data/mpi/client_handle_specializations.hh
+++ b/flecsi/data/mpi/client_handle_specializations.hh
@@ -15,10 +15,7 @@
 
 /*! @file */
 
-#define POLICY_NAMESPACE mpi
 #include <flecsi/data/common/client_handle_specialization.hh>
-#undef POLICY_NAMESPACE
-
 #include <flecsi/data/common/client_handle.hh>
 
 namespace flecsi {

--- a/flecsi/data/mpi/data_policy.hh
+++ b/flecsi/data/mpi/data_policy.hh
@@ -45,18 +45,6 @@ struct mpi_data_policy_t {
       NAME>();
   } // get_client_handle
 
-  /*--------------------------------------------------------------------------*
-    Storage Class Interface.
-   *--------------------------------------------------------------------------*/
-
-  /*
-    Capture the base storage class type. This is necessary as a place
-    holder in the field interface.
-   */
-
-  template<size_t STORAGE_CLASS, typename CLIENT_TYPE>
-  using storage_class_u = storage_class_u<STORAGE_CLASS, CLIENT_TYPE>;
-
 }; // struct mpi_data_policy_t
 
 } // namespace data

--- a/flecsi/data/mpi/data_policy.hh
+++ b/flecsi/data/mpi/data_policy.hh
@@ -55,7 +55,7 @@ struct mpi_data_policy_t {
    */
 
   template<size_t STORAGE_CLASS, typename CLIENT_TYPE>
-  using storage_class_u = mpi::storage_class_u<STORAGE_CLASS, CLIENT_TYPE>;
+  using storage_class_u = storage_class_u<STORAGE_CLASS, CLIENT_TYPE>;
 
 }; // struct mpi_data_policy_t
 

--- a/flecsi/data/mpi/storage_classes.hh
+++ b/flecsi/data/mpi/storage_classes.hh
@@ -15,9 +15,7 @@
 
 /*! @file */
 
-#define POLICY_NAMESPACE mpi
 #include <flecsi/data/common/storage_class.hh>
-#undef POLICY_NAMESPACE
 
 namespace flecsi {
 namespace data {


### PR DESCRIPTION
Minor work so far on supporting only a single backend per compilation.  The next task is to remove the `field_interface_u` class template and make its (static) member functions be namespace-scope functions that use, if anything, a _typedef-name_ to refer to the backend-specific code.