### PR TITLE
This fixes a set of warnings and other minor system-specific issues

### DIFF
--- a/arch/developer-gnu
+++ b/arch/developer-gnu
@@ -79,6 +79,7 @@ $cmake_mode \
   -DENABLE_FLECSIT=ON \
   -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} \
   -DENABLE_KOKKOS=$kokkos \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   $cinch_dir
 
 #------------------------------------------------------------------------------#

--- a/flecsi/coloring/crs.h
+++ b/flecsi/coloring/crs.h
@@ -24,10 +24,14 @@ namespace coloring {
 // Convenience macro to avoid having to reimplement this for each member.
 //----------------------------------------------------------------------------//
 
+// initialize with an explicit loop to circumvent integral conversion warnings
 #define define_as(member)                                                      \
   template<typename T>                                                         \
   std::vector<T> member##_as() const {                                         \
-    std::vector<T> asvec(member.begin(), member.end());                        \
+    std::vector<T> asvec;                                                      \
+    asvec.reserve(member.size());                                              \
+    for(auto v : member)                                                       \
+      asvec.push_back(static_cast<T>(v));                                      \
     return asvec;                                                              \
   }
 
@@ -255,10 +259,10 @@ operator<<(std::ostream & stream, const crs_t & crs) {
 struct dcrs_t : public crs_t {
   std::vector<size_t> distribution;
 
-  define_as(distribution)
+  define_as(distribution);
 
-    /// \brief clears the current storage
-    void clear() {
+  /// \brief clears the current storage
+  void clear() {
     crs_t::clear();
     distribution.clear();
   }

--- a/flecsi/coloring/dcrs_utils.h
+++ b/flecsi/coloring/dcrs_utils.h
@@ -321,8 +321,8 @@ alltoallv(const SEND_TYPE & sendbuf,
       auto buf = recvbuf.data() + recvdispls[rank];
       requests.resize(requests.size() + 1);
       auto & my_request = requests.back();
-      auto ret =
-        MPI_Irecv(buf, count, mpi_recv_t, rank, tag, comm, &my_request);
+      auto ret = MPI_Irecv(buf, static_cast<int>(count), mpi_recv_t,
+        static_cast<int>(rank), tag, comm, &my_request);
       if(ret != MPI_SUCCESS)
         return ret;
     }
@@ -335,8 +335,8 @@ alltoallv(const SEND_TYPE & sendbuf,
       auto buf = sendbuf.data() + senddispls[rank];
       requests.resize(requests.size() + 1);
       auto & my_request = requests.back();
-      auto ret =
-        MPI_Isend(buf, count, mpi_send_t, rank, tag, comm, &my_request);
+      auto ret = MPI_Isend(buf, static_cast<int>(count), mpi_send_t,
+        static_cast<int>(rank), tag, comm, &my_request);
       if(ret != MPI_SUCCESS)
         return ret;
     }
@@ -344,7 +344,8 @@ alltoallv(const SEND_TYPE & sendbuf,
 
   // wait for everything to complete
   std::vector<MPI_Status> status(requests.size());
-  auto ret = MPI_Waitall(requests.size(), requests.data(), status.data());
+  auto ret = MPI_Waitall(
+    static_cast<int>(requests.size()), requests.data(), status.data());
 
   return ret;
 }
@@ -436,7 +437,7 @@ make_dcrs_distributed(
 
   size_t max_global_vert_id{0};
   for(auto v : vertex_local_to_global)
-    max_global_vert_id = std::max(max_global_vert_id, v);
+    max_global_vert_id = (std::max)(max_global_vert_id, v);
 
   // now the global max id
   size_t tot_verts{0};
@@ -1096,9 +1097,9 @@ color_entities(const flecsi::coloring::crs_t & cells2entity,
   std::vector<size_t> recvcounts(comm_size);
   auto ret = MPI_Alltoall(sendcounts.data(), 1, mpi_size_t, recvcounts.data(),
     1, mpi_size_t, MPI_COMM_WORLD);
-  if(ret != MPI_SUCCESS)
+  if(ret != MPI_SUCCESS) {
     clog_error("Error communicating vertex counts");
-
+  }
   // how much info will we be receiving
   std::vector<size_t> recvdispls(comm_size + 1);
   recvdispls[0] = 0;
@@ -1112,9 +1113,9 @@ color_entities(const flecsi::coloring::crs_t & cells2entity,
   // now send the actual vertex info
   ret = alltoallv(sendbuf, sendcounts, senddispls, recvbuf, recvcounts,
     recvdispls, MPI_COMM_WORLD);
-  if(ret != MPI_SUCCESS)
+  if(ret != MPI_SUCCESS) {
     clog_error("Error communicating vertices");
-
+  }
   //----------------------------------------------------------------------------
   // Unpack results
   //----------------------------------------------------------------------------
@@ -1149,7 +1150,7 @@ color_entities(const flecsi::coloring::crs_t & cells2entity,
   // first figure out the maximum global id on this rank
   size_t max_global_ent_id{0};
   for(auto v : local2global)
-    max_global_ent_id = std::max(max_global_ent_id, v);
+    max_global_ent_id = (std::max)(max_global_ent_id, v);
 
   // now the global max id
   size_t tot_ents{0};
@@ -1217,9 +1218,9 @@ color_entities(const flecsi::coloring::crs_t & cells2entity,
   // send counts
   ret = MPI_Alltoall(sendcounts.data(), 1, mpi_size_t, recvcounts.data(), 1,
     mpi_size_t, MPI_COMM_WORLD);
-  if(ret != MPI_SUCCESS)
+  if(ret != MPI_SUCCESS) {
     clog_error("Error communicating vertex counts");
-
+  }
   // how much info will we be receiving
   recvdispls[0] = 0;
   for(size_t r = 0; r < comm_size; ++r)
@@ -1231,8 +1232,9 @@ color_entities(const flecsi::coloring::crs_t & cells2entity,
   // now send the actual vertex info
   ret = alltoallv(sendbuf, sendcounts, senddispls, recvbuf, recvcounts,
     recvdispls, MPI_COMM_WORLD);
-  if(ret != MPI_SUCCESS)
+  if(ret != MPI_SUCCESS) {
     clog_error("Error communicating vertices");
+  }
 
   // upack results
   for(size_t r = 0; r < comm_size; ++r) {
@@ -1293,8 +1295,9 @@ color_entities(const flecsi::coloring::crs_t & cells2entity,
   // send counts
   ret = MPI_Alltoall(sendcounts.data(), 1, mpi_size_t, recvcounts.data(), 1,
     mpi_size_t, MPI_COMM_WORLD);
-  if(ret != MPI_SUCCESS)
+  if(ret != MPI_SUCCESS) {
     clog_error("Error communicating vertex counts");
+  }
 
   // how much info will we be receiving
   recvdispls[0] = 0;
@@ -1307,9 +1310,9 @@ color_entities(const flecsi::coloring::crs_t & cells2entity,
   // now send the actual vertex info
   ret = alltoallv(sendbuf, sendcounts, senddispls, recvbuf, recvcounts,
     recvdispls, MPI_COMM_WORLD);
-  if(ret != MPI_SUCCESS)
+  if(ret != MPI_SUCCESS) {
     clog_error("Error communicating vertices");
-
+  }
   // upack results
   for(size_t r = 0; r < comm_size; ++r) {
     for(size_t i = recvdispls[r]; i < recvdispls[r + 1]; i++) {
@@ -1378,9 +1381,9 @@ color_entities(const flecsi::coloring::crs_t & cells2entity,
   // send counts
   ret = MPI_Alltoall(sendcounts.data(), 1, mpi_size_t, recvcounts.data(), 1,
     mpi_size_t, MPI_COMM_WORLD);
-  if(ret != MPI_SUCCESS)
+  if(ret != MPI_SUCCESS) {
     clog_error("Error communicating vertex counts");
-
+  }
   // how much info will we be receiving
   recvdispls[0] = 0;
   for(size_t r = 0; r < comm_size; ++r)
@@ -1392,8 +1395,9 @@ color_entities(const flecsi::coloring::crs_t & cells2entity,
   // now send the actual vertex info
   ret = alltoallv(sendbuf, sendcounts, senddispls, recvbuf, recvcounts,
     recvdispls, MPI_COMM_WORLD);
-  if(ret != MPI_SUCCESS)
+  if(ret != MPI_SUCCESS) {
     clog_error("Error communicating vertices");
+  }
 
   // upack results
   for(size_t r = 0; r < comm_size; ++r) {
@@ -1428,7 +1432,7 @@ color_entities(const flecsi::coloring::crs_t & cells2entity,
   }
 
   // shared and ghost
-  for(const auto pair : entities2rank) {
+  for(const auto & pair : entities2rank) {
     auto global_id = pair.first;
     auto owner = pair.second;
     // if i am the owner, shared
@@ -1484,7 +1488,7 @@ match_ids(
 
   size_t max_global_vert_id{0};
   for(auto v : vertex_local2global)
-    max_global_vert_id = std::max(max_global_vert_id, v);
+    max_global_vert_id = (std::max)(max_global_vert_id, v);
 
   // now the global max id
   size_t tot_verts{0};
@@ -1808,9 +1812,9 @@ ghost_connectivity(const flecsi::coloring::crs_t & from2to,
   std::vector<size_t> recvcounts(comm_size);
   auto ret = MPI_Alltoall(sendcounts.data(), 1, mpi_size_t, recvcounts.data(),
     1, mpi_size_t, MPI_COMM_WORLD);
-  if(ret != MPI_SUCCESS)
+  if(ret != MPI_SUCCESS) {
     clog_error("Error communicating vertex counts");
-
+  }
   // how much info will we be receiving
   std::vector<size_t> recvdispls(comm_size + 1);
   recvdispls[0] = 0;
@@ -1821,9 +1825,9 @@ ghost_connectivity(const flecsi::coloring::crs_t & from2to,
   // now send the actual vertex info
   ret = alltoallv(sendbuf, sendcounts, senddispls, recvbuf, recvcounts,
     recvdispls, MPI_COMM_WORLD);
-  if(ret != MPI_SUCCESS)
+  if(ret != MPI_SUCCESS) {
     clog_error("Error communicating vertices");
-
+  }
   //----------------------------------------------------------------------------
   // Unpack results
   //----------------------------------------------------------------------------

--- a/flecsi/coloring/mpi_communicator.h
+++ b/flecsi/coloring/mpi_communicator.h
@@ -613,13 +613,13 @@ public:
     std::unordered_map<size_t, coloring_info_t> coloring_info;
 
     for(size_t c(0); c < colors; ++c) {
-      auto  & ci = coloring_info[c];
+      auto & ci = coloring_info[c];
       ci.exclusive = buffer[c].exclusive;
       ci.shared = buffer[c].shared;
       ci.ghost = buffer[c].ghost;
     } // for
 
-#if  0
+#if 0
     alltoall_coloring_info(
       color_info.shared_users, [&](size_t c, size_t value) {
         coloring_info[c].shared_users.insert(value);

--- a/flecsi/coloring/parmetis_colorer.h
+++ b/flecsi/coloring/parmetis_colorer.h
@@ -263,14 +263,14 @@ struct parmetis_colorer_t : public colorer_t {
     idx_t wgtflag = 0;
     idx_t numflag = 0;
     idx_t ncon = 1;
-    std::vector<real_t> tpwgts(ncon * size, 1.0 / size);
+    std::vector<real_t> tpwgts(ncon * size, static_cast<real_t>(1.0 / size));
 
     // We may need to expose some of the ParMETIS configuration options.
-    std::vector<real_t> ubvec(ncon, 1.05);
+    std::vector<real_t> ubvec(ncon, static_cast<real_t>(1.05));
     idx_t options[3] = {0, 0, 0};
     idx_t edgecut;
     MPI_Comm comm = MPI_COMM_WORLD;
-    std::vector<idx_t> part(dcrs.size(), std::numeric_limits<idx_t>::max());
+    std::vector<idx_t> part(dcrs.size(), (std::numeric_limits<idx_t>::max)());
 
     // Get the dCRS information using ParMETIS types.
     std::vector<idx_t> vtxdist = dcrs.distribution_as<idx_t>();
@@ -281,8 +281,9 @@ struct parmetis_colorer_t : public colorer_t {
     int result = ParMETIS_V3_PartKway(&vtxdist[0], &xadj[0], &adjncy[0],
       nullptr, nullptr, &wgtflag, &numflag, &ncon, &size, &tpwgts[0],
       ubvec.data(), options, &edgecut, &part[0], &comm);
-    if(result != METIS_OK)
+    if(result != METIS_OK) {
       clog_error("Parmetis failed!");
+    }
 
     std::vector<size_t> partitioning(part.begin(), part.end());
 

--- a/flecsi/data/common/registration_wrapper.h
+++ b/flecsi/data/common/registration_wrapper.h
@@ -80,11 +80,13 @@ struct field_registration_wrapper_u {
     // register custom serdez op, if applicable
     if constexpr(STORAGE_CLASS == ragged) {
       using serdez_t = serdez_u<row_vector_u<DATA_TYPE>>;
-      execution::context_t::instance().register_serdez<serdez_t>(fid);
+      execution::context_t::instance().register_serdez<serdez_t>(
+        static_cast<int32_t>(fid));
     } // if
     else if constexpr(STORAGE_CLASS == sparse) {
       using serdez_t = serdez_u<row_vector_u<sparse_entry_value_u<DATA_TYPE>>>;
-      execution::context_t::instance().register_serdez<serdez_t>(fid);
+      execution::context_t::instance().register_serdez<serdez_t>(
+        static_cast<int32_t>(fid));
     }
   } // register_callback
 

--- a/flecsi/data/common/row_vector.h
+++ b/flecsi/data/common/row_vector.h
@@ -92,7 +92,7 @@ struct row_vector_u {
   }
 
   void assign(const_iterator first, const_iterator last) {
-    resize(last - first);
+    resize(static_cast<uint32_t>(last - first));
     std::copy(first, last, datap);
   }
 

--- a/flecsi/data/data_client_handle.h
+++ b/flecsi/data/data_client_handle.h
@@ -50,7 +50,7 @@ struct data_client_handle_base_u : public DATA_CLIENT_TYPE,
   data_client_handle_base_u(const data_client_handle_base_u<DATA_CLIENT_TYPE,
     UNMAPPED_PERMISSIONS,
     DATA_POLICY> & h)
-    : DATA_POLICY(h), DATA_CLIENT_TYPE(h), type_hash(h.type_hash),
+    : DATA_CLIENT_TYPE(h), DATA_POLICY(h), type_hash(h.type_hash),
       name_hash(h.name_hash), namespace_hash(h.namespace_hash) {
     static_assert(
       UNMAPPED_PERMISSIONS == 0, "passing mapped client handle to task args");

--- a/flecsi/data/ragged_accessor.h
+++ b/flecsi/data/ragged_accessor.h
@@ -141,7 +141,7 @@ struct accessor_u<data::ragged,
     auto & row = this->handle.rows[index];
     assert(ragged_index < row.size() && "ragged accessor: index out of range");
 
-    return row[ragged_index];
+    return row[static_cast<int>(ragged_index)];
   } // operator ()
 
   const T & operator()(size_t index, size_t ragged_index) const {

--- a/flecsi/data/ragged_mutator.h
+++ b/flecsi/data/ragged_mutator.h
@@ -62,13 +62,12 @@ struct mutator_u<data::ragged, T> : public mutator_u<data::base, T>,
 
   T & operator()(size_t index, size_t ragged_index) {
     auto & row = this->handle[index];
-    return row[ragged_index];
-
+    return row[static_cast<uint32_t>(ragged_index)];
   } // operator ()
 
   void resize(size_t index, size_t size) {
     auto & row = this->handle[index];
-    row.resize(size);
+    row.resize(static_cast<uint32_t>(size));
   } // resize
 
   void erase(size_t index, size_t ragged_index) {

--- a/flecsi/execution/CMakeLists.txt
+++ b/flecsi/execution/CMakeLists.txt
@@ -29,6 +29,7 @@ set(execution_HEADERS
   global_object_wrapper.h
   internal_index_space.h
   kernel.h
+  reduction.h
   remap_shared.h
   task.h
 )

--- a/flecsi/execution/legion/future.h
+++ b/flecsi/execution/legion/future.h
@@ -256,7 +256,17 @@ struct legion_future_u<RETURN, launch_type_t::index> : public future_base_t {
    */
 
   RETURN
-  get(size_t index = 0, bool silence_warnings = false) {
+  get(size_t index, bool silence_warnings = false) {
+    return legion_future_.get_result<RETURN>(
+      Legion::DomainPoint::from_point<1>(
+        LegionRuntime::Arrays::Point<1>(index)),
+      silence_warnings);
+  } // get
+
+  RETURN
+  get(bool silence_warnings = false) {
+    auto runtime = Legion::Runtime::get_runtime();
+    size_t index = runtime->find_local_MPI_rank();
     return legion_future_.get_result<RETURN>(
       Legion::DomainPoint::from_point<1>(
         LegionRuntime::Arrays::Point<1>(index)),

--- a/flecsi/execution/remap_shared.h
+++ b/flecsi/execution/remap_shared.h
@@ -80,8 +80,8 @@ remap_shared_entities() {
         buf.resize(n);
         requests.resize(requests.size() + 1);
         auto & my_request = requests.back();
-        auto ret = MPI_Irecv(
-          buf.data(), n, mpi_size_t, rank, tag, MPI_COMM_WORLD, &my_request);
+        auto ret = MPI_Irecv(buf.data(), static_cast<int>(n), mpi_size_t,
+          static_cast<int>(rank), tag, MPI_COMM_WORLD, &my_request);
       }
     }
 
@@ -92,13 +92,14 @@ remap_shared_entities() {
       const auto & buf = comm_pair.second;
       requests.resize(requests.size() + 1);
       auto & my_request = requests.back();
-      auto ret = MPI_Isend(buf.data(), buf.size(), mpi_size_t, rank, tag,
-        MPI_COMM_WORLD, &my_request);
+      auto ret = MPI_Isend(buf.data(), static_cast<int>(buf.size()), mpi_size_t,
+        static_cast<int>(rank), tag, MPI_COMM_WORLD, &my_request);
     }
 
     // wait for everything to complete
     std::vector<MPI_Status> status(requests.size());
-    MPI_Waitall(requests.size(), requests.data(), status.data());
+    MPI_Waitall(
+      static_cast<int>(requests.size()), requests.data(), status.data());
 
     // now we can unpack the messages and reconstruct the ghost entities
     std::set<flecsi::coloring::entity_info_t> new_ghost;

--- a/flecsi/execution/test/data_client_handle.cc
+++ b/flecsi/execution/test/data_client_handle.cc
@@ -41,7 +41,7 @@ fill_task(client_handle_t<test_mesh_t, ro> mesh,
   dense_accessor<double, rw, rw, na> pressure) {
   size_t count = 0;
   for(auto c : mesh.cells()) {
-    pressure(c) = count++;
+    pressure(c) = static_cast<double>(count++);
   } // for
 } // fill_task
 
@@ -57,7 +57,7 @@ print_task(client_handle_t<test_mesh_t, ro> mesh,
       CINCH_CAPTURE() << "vertex id: " << v->id() << std::endl;
     } // for
 
-    clog(info) << "presure: " << pressure(c) << std::endl;
+    clog(info) << "pressure: " << pressure(c) << std::endl;
   } // for
 
 } // print_task

--- a/flecsi/execution/test/devel_handle.cc
+++ b/flecsi/execution/test/devel_handle.cc
@@ -5,6 +5,7 @@
 
 #include <cinchdevel.h>
 
+#include <flecsi/data/data.h>
 #include <flecsi/data/dense_accessor.h>
 #include <flecsi/execution/context.h>
 #include <flecsi/execution/execution.h>

--- a/flecsi/execution/test/finite_difference_dense.cc
+++ b/flecsi/execution/test/finite_difference_dense.cc
@@ -106,7 +106,7 @@ flecsi_register_task(init, flecsi::execution, loc, index);
 void
 check_results(mesh<ro> mesh, field<ro, ro, ro> values, size_t global_target) {
   auto target = flecsi_get_global_object(global_target, global, vec_2d_t);
-  auto rank = context_t::instance().color();
+  size_t rank = context_t::instance().color();
 
   for(auto c : mesh.cells(owned)) {
     auto v = values(c);
@@ -115,7 +115,7 @@ check_results(mesh<ro> mesh, field<ro, ro, ro> values, size_t global_target) {
     auto t = (*target)[i][j];
 
     if(std::abs(v - t) > test_tolerance) {
-      printf("[Rank %lu] at [%lu,%lu] %.15e != %.15e\n", rank, i, j, v, t);
+      printf("[Rank %zu] at [%zu,%zu] %.15e != %.15e\n", rank, i, j, v, t);
       throw std::runtime_error("Got wrong result");
     }
   }

--- a/flecsi/execution/test/finite_difference_sparse.cc
+++ b/flecsi/execution/test/finite_difference_sparse.cc
@@ -104,7 +104,7 @@ check_results(mesh<ro> mesh,
   size_t field_idx,
   size_t global_target) {
   auto target = flecsi_get_global_object(global_target, global, vec_2d_t);
-  auto rank = context_t::instance().color();
+  size_t rank = context_t::instance().color();
 
   for(auto c : mesh.cells(owned)) {
     auto v = values(c, field_idx);
@@ -113,7 +113,7 @@ check_results(mesh<ro> mesh,
     auto t = (*target)[i][j];
 
     if(std::abs(v - t) > test_tolerance) {
-      printf("[Rank %lu] at [%lu,%lu] %.15e != %.15e\n", rank, i, j, v, t);
+      printf("[Rank %zu] at [%zu,%zu] %.15e != %.15e\n", rank, i, j, v, t);
       throw std::runtime_error("Got wrong result");
     }
   }

--- a/flecsi/execution/test/future_handle.cc
+++ b/flecsi/execution/test/future_handle.cc
@@ -19,7 +19,7 @@
 //----------------------------------------------------------------------------//
 
 template<typename T>
-using handle_t =
+using future_handle_t =
   flecsi::execution::flecsi_future<T, flecsi::execution::launch_type_t::single>;
 
 template<typename T>
@@ -27,7 +27,7 @@ using index_handle_t =
   flecsi::execution::flecsi_future<T, flecsi::execution::launch_type_t::index>;
 
 void
-future_dump(handle_t<double> x) {
+future_dump(future_handle_t<double> x) {
   double tmp = x.get();
   std::cout << " future = " << x.get() << std::endl;
 }
@@ -43,7 +43,7 @@ writer(double a) {
 flecsi_register_task(writer, , loc, single);
 
 void
-reader(handle_t<double> x, handle_t<double> y) {
+reader(future_handle_t<double> x, future_handle_t<double> y) {
   ASSERT_EQ(x.get(), static_cast<double>(3.14));
   ASSERT_EQ(x.get(), y.get());
 }
@@ -52,7 +52,8 @@ flecsi_register_task(reader, , loc, single);
 
 int
 index_writer() {
-  int x = 1 + flecsi::execution::context_t::instance().color();
+  int x =
+    1 + static_cast<int>(flecsi::execution::context_t::instance().color());
   return x;
 }
 
@@ -60,8 +61,9 @@ flecsi_register_task(index_writer, , loc, index);
 
 void
 index_reader(index_handle_t<int> x) {
-  int y = 1 + flecsi::execution::context_t::instance().color();
-  ASSERT_EQ(x, y);
+  int y =
+    1 + static_cast<int>(flecsi::execution::context_t::instance().color());
+  ASSERT_EQ(x.get(), y);
 }
 
 flecsi_register_task(index_reader, , loc, index);

--- a/flecsi/execution/test/handle_list.cc
+++ b/flecsi/execution/test/handle_list.cc
@@ -35,8 +35,8 @@ write_task(data_client_handle_u<mesh_t, ro> mesh,
   auto & context = execution::context_t::instance();
   const auto & map = context.index_map(cells);
   for(auto c : mesh.cells(flecsi::owned)) {
-    fs[0](c) = map.at(c.id());
-    fs[1](c) = 2 * map.at(c.id());
+    fs[0](c) = static_cast<int>(map.at(c.id()));
+    fs[1](c) = static_cast<int>(2 * map.at(c.id()));
   }
 } // task1
 

--- a/flecsi/execution/test/handle_tuple.cc
+++ b/flecsi/execution/test/handle_tuple.cc
@@ -33,8 +33,8 @@ write_task(data_client_handle_u<mesh_t, ro> mesh,
   auto & context = execution::context_t::instance();
   const auto & map = context.index_map(cells);
   for(auto c : mesh.cells(flecsi::owned)) {
-    std::get<0>(fs)(c) = map.at(c.id());
-    std::get<1>(fs)(c) = 2 * map.at(c.id());
+    std::get<0>(fs)(c) = static_cast<int>(map.at(c.id()));
+    std::get<1>(fs)(c) = static_cast<int>(2 * map.at(c.id()));
   }
 } // task1
 

--- a/flecsi/execution/test/ragged_data.cc
+++ b/flecsi/execution/test/ragged_data.cc
@@ -37,7 +37,7 @@ init(client_handle_t<test_mesh_t, ro> mesh, ragged_mutator<double> rm) {
       count = 8;
     rm.resize(c, count);
     for(size_t j = 0; j < count; ++j) {
-      rm(c, j) = rank * 10000 + gid * 100 + j;
+      rm(c, j) = static_cast<double>(rank * 10000 + gid * 100 + j);
     }
   }
 } // init
@@ -64,14 +64,14 @@ mutate(client_handle_t<test_mesh_t, ro> mesh, ragged_mutator<double> rm) {
     if(gid == 11 || gid == 14) {
       rm.resize(c, 10);
       for(size_t j = 3; j < 10; ++j) {
-        rm(c, j) = rank * 10000 + gid * 100 + 50 + j;
+        rm(c, j) = static_cast<double>(rank * 10000 + gid * 100 + 50 + j);
       }
       rm.erase(c, 1);
     }
     else if(gid == 13) {
       auto n = rank * 10000 + gid * 100 + 66;
-      rm.push_back(c, n);
-      rm.insert(c, 1, n + 1);
+      rm.push_back(c, static_cast<double>(n));
+      rm.insert(c, 1, static_cast<double>(n + 1));
     }
     // flip the checkerboard:  entries that had 3 entries will now
     // have 2, and vice-versa
@@ -81,7 +81,7 @@ mutate(client_handle_t<test_mesh_t, ro> mesh, ragged_mutator<double> rm) {
     }
     else {
       auto n = rank * 10000 + gid * 100 + 88;
-      rm.insert(c, 1, n);
+      rm.insert(c, 1, static_cast<double>(n));
       rm(c, 2) = -rm(c, 2) + 80;
     }
   }

--- a/flecsi/execution/test/reduction_interface.cc
+++ b/flecsi/execution/test/reduction_interface.cc
@@ -61,7 +61,7 @@ min_task(mesh<ro> m, field<rw, rw, ro> v) {
   double min{1000000.0};
 
   for(auto c : m.cells(owned)) {
-    min = std::min(v(c), min);
+    min = (std::min)(v(c), min);
   } // for
 
   return min;
@@ -71,7 +71,7 @@ max_task(mesh<ro> m, field<rw, rw, ro> v) {
   double max{0.0};
 
   for(auto c : m.cells(owned)) {
-    max = std::max(v(c), max);
+    max = (std::max)(v(c), max);
   } // for
 
   return max;

--- a/flecsi/execution/test/sparse_data.cc
+++ b/flecsi/execution/test/sparse_data.cc
@@ -37,7 +37,7 @@ init(client_handle_t<test_mesh_t, ro> mesh, sparse_mutator<double> sm) {
     if(gid >= 11 && gid <= 13)
       stop = (parity ? 16 : 17);
     for(size_t j = start; j < stop; j += 2) {
-      sm(c, j) = rank * 10000 + gid * 100 + j;
+      sm(c, j) = static_cast<double>(rank * 10000 + gid * 100 + j);
     }
   }
 } // init
@@ -64,7 +64,7 @@ mutate(client_handle_t<test_mesh_t, ro> mesh, sparse_mutator<double> sm) {
       int start = (parity ? 6 : 5);
       int stop = (parity ? 20 : 21);
       for(size_t j = start; j < stop; j += 2) {
-        sm(c, j) = rank * 10000 + gid * 100 + 50 + j;
+        sm(c, j) = static_cast<double>(rank * 10000 + gid * 100 + 50 + j);
       }
       sm.erase(c, start - 4);
       sm.erase(c, stop - 4);
@@ -73,10 +73,10 @@ mutate(client_handle_t<test_mesh_t, ro> mesh, sparse_mutator<double> sm) {
       sm.erase(c, 9);
     }
     else if(parity) {
-      sm(c, 6) = rank * 10000 + gid * 100 + 66;
+      sm(c, 6) = static_cast<double>(rank * 10000 + gid * 100 + 66);
     }
     else {
-      sm(c, 3) = rank * 10000 + gid * 100 + 77;
+      sm(c, 3) = static_cast<double>(rank * 10000 + gid * 100 + 77);
     }
   }
 } // mutate

--- a/flecsi/execution/test/unordered_ispaces.cc
+++ b/flecsi/execution/test/unordered_ispaces.cc
@@ -107,6 +107,9 @@ driver(int argc, char ** argv) {
 #elif FLECSI_RUNTIME_MODEL == FLECSI_RUNTIME_MODEL_mpi
   int my_color;
   MPI_Comm_rank(MPI_COMM_WORLD, &my_color);
+#elif FLECSI_RUNTIME_MODEL == FLECSI_RUNTIME_MODEL_hpx
+  int my_color;
+  MPI_Comm_rank(MPI_COMM_WORLD, &my_color);
 #endif
 
   clog(trace) << "Rank " << my_color << " in driver" << std::endl;
@@ -351,7 +354,7 @@ add_colorings(int dummy) {
     // Get the set of cells that reference this vertex.
     auto referencers = flecsi::topology::entity_referencers<2, 0>(sd, i);
 
-    size_t min_rank(std::numeric_limits<size_t>::max());
+    size_t min_rank((std::numeric_limits<size_t>::max)());
     std::set<size_t> shared_vertices;
 
     // Iterate the direct referencers to assign vertex ownership.

--- a/flecsi/io/CMakeLists.txt
+++ b/flecsi/io/CMakeLists.txt
@@ -140,21 +140,21 @@ endif()
 
 if(FLECSI_RUNTIME_MODEL STREQUAL "legion" AND ENABLE_HDF5)
 
-cinch_add_unit(io_hdf5
-  SOURCES
-    test/legion/io_hdf5.cc
-    ${DRIVER_INITIALIZATION}
-    ${RUNTIME_DRIVER}
-  DEFINES
-    -DCINCH_OVERRIDE_DEFAULT_INITIALIZATION_DRIVER
-  POLICY
-    ${UNIT_POLICY}
-  LIBRARIES
-    FleCSI
-    ${CINCH_RUNTIME_LIBRARIES}
-    ${HDF5_LIBRARIES}
-  THREADS 4
-)
+  cinch_add_unit(io_hdf5
+    SOURCES
+      test/legion/io_hdf5.cc
+      ${DRIVER_INITIALIZATION}
+      ${RUNTIME_DRIVER}
+    DEFINES
+      -DCINCH_OVERRIDE_DEFAULT_INITIALIZATION_DRIVER
+    POLICY
+      ${UNIT_POLICY}
+    LIBRARIES
+      FleCSI
+      ${CINCH_RUNTIME_LIBRARIES}
+      ${HDF5_LIBRARIES}
+    THREADS 4
+  )
 endif()
 
 cinch_add_unit(simple_definition

--- a/flecsi/supplemental/coloring/coloring_functions.h
+++ b/flecsi/supplemental/coloring/coloring_functions.h
@@ -81,7 +81,7 @@ color_entity(topology::mesh_definition_u<DIMENSION> const & md,
       } // guard
 #endif
 
-      size_t min_rank(std::numeric_limits<size_t>::max());
+      size_t min_rank((std::numeric_limits<size_t>::max)());
       std::set<size_t> shared_entities;
 
       // Iterate the direct referencers to assign entity ownership.
@@ -168,9 +168,9 @@ color_entity(topology::mesh_definition_u<DIMENSION> const & md,
   {
     clog_tag_guard(coloring_functions);
     clog_container_one(
-      info, 
-      "exclusive entities("<<ENTITY_DIM<<")", 
-      entities.exclusive, 
+      info,
+      "exclusive entities("<<ENTITY_DIM<<")",
+      entities.exclusive,
       clog::newline
     );
     clog_container_one(

--- a/flecsi/supplemental/coloring/concept_coloring.h
+++ b/flecsi/supplemental/coloring/concept_coloring.h
@@ -213,7 +213,7 @@ generic_coloring(typename COLORING_POLICY::mesh_definition_t & md,
         auto referencers =
           entity_referencers<primary_dimension, dimension>(md, i);
 
-        size_t min_rank(std::numeric_limits<size_t>::max());
+        size_t min_rank((std::numeric_limits<size_t>::max)());
         std::set<size_t> shared_entities;
 
         // Iterate the direct referencers to assign entity ownership

--- a/flecsi/supplemental/coloring/tikz.h
+++ b/flecsi/supplemental/coloring/tikz.h
@@ -71,7 +71,8 @@ struct tikz_writer_t {
       const size_t round_robin(c.first % palette.size());
 
       for(size_t id : c.second) {
-        write_node(tex, id % (N + 1), id / (N + 1), id, round_robin);
+        write_node(tex, static_cast<double>(id % (N + 1)),
+          static_cast<double>(id / (N + 1)), id, round_robin);
       } // for
     } // for
 
@@ -142,9 +143,9 @@ struct tikz_writer_t {
 
     size_t vertex(0);
     for(size_t j(0); j < M + 1; ++j) {
-      double yoff(j);
+      double yoff(static_cast<double>(j));
       for(size_t i(0); i < N + 1; ++i) {
-        double xoff(i);
+        double xoff(static_cast<double>(i));
 
         auto evertex = exclusive_vertices.find(vertex);
         auto svertex = shared_vertices.find(vertex);

--- a/flecsi/supplemental/mesh/test_mesh_2d.h
+++ b/flecsi/supplemental/mesh/test_mesh_2d.h
@@ -19,6 +19,7 @@
 
 #include <cinchlog.h>
 
+#include <flecsi/data/common/privilege.h>
 #include <flecsi/data/data_client_handle.h>
 #include <flecsi/execution/execution.h>
 #include <flecsi/supplemental/coloring/add_colorings.h>
@@ -265,7 +266,7 @@ do_test_mesh_2d_coloring() {
 //----------------------------------------------------------------------------//
 
 void
-initialize_mesh(data_client_handle_u<test_mesh_2d_t, wo> mesh) {
+initialize_mesh(data_client_handle_u<test_mesh_2d_t, flecsi::wo> mesh) {
   auto & context = execution::context_t::instance();
 
   auto & vertex_map{context.index_map(index_spaces::vertices)};

--- a/flecsi/topology/test/pseudo_random.h
+++ b/flecsi/topology/test/pseudo_random.h
@@ -23,7 +23,7 @@ public:
   //! \brief Generate a new random number with a uniform distribution between
   //!        [0, 1).
   double uniform() {
-    return double(rng_()) / rng_.max();
+    return double(rng_()) / (rng_.max)();
   }
 
   //! \brief Generate a new random number with a uniform distribution between

--- a/flecsi/utils/CMakeLists.txt
+++ b/flecsi/utils/CMakeLists.txt
@@ -135,6 +135,7 @@ cinch_add_unit(factory
   SOURCES
     demangle.cc
     test/factory.cc
+    ${utils_SOURCES}
   INPUTS
     test/factory.blessed
     ${factory_blessed_input}
@@ -192,6 +193,7 @@ cinch_add_unit(test_utility
   SOURCES
     demangle.cc
     test/utility.cc
+    ${utils_SOURCES}
   INPUTS
     test/utility.blessed.gnug
 )
@@ -206,6 +208,7 @@ cinch_add_unit(tuple_type_converter
   SOURCES
     demangle.cc
     test/tuple_type_converter.cc
+    ${utils_SOURCES}
   INPUTS
     ${tuple_type_converter_blessed_input}
 )
@@ -226,6 +229,7 @@ cinch_add_unit(array_ref
   SOURCES
     demangle.cc
     test/array_ref.cc
+    ${utils_SOURCES}
   INPUTS
     test/array_ref.blessed ${array_ref_blessed_input}
 )
@@ -240,6 +244,7 @@ cinch_add_unit(common
   SOURCES
     demangle.cc
     test/common.cc
+    ${utils_SOURCES}
   INPUTS
     test/common.blessed.ppc test/common.blessed ${common_blessed_input}
 )
@@ -254,6 +259,7 @@ cinch_add_unit(id
   SOURCES
     demangle.cc
     test/id.cc
+    ${utils_SOURCES}
   INPUTS
     test/id.blessed ${id_blessed_input}
 )

--- a/flecsi/utils/annotation.h
+++ b/flecsi/utils/annotation.h
@@ -73,6 +73,7 @@ public:
   struct runtime_finish : region<execution> {
     inline static const std::string name{"finish"};
   };
+#if !defined(_MSC_VER)
   template<class T>
   struct execute_task : region<execution> {
     /// Set code region name for regions inheriting from execute_task with the
@@ -102,7 +103,50 @@ public:
     inline static const std::string tag{"finalize-handles"};
     static constexpr detail detail_level = detail::high;
   };
-
+#else
+  // MSVC is eagerly instantiating things, we must work around this
+  template<class T>
+  struct execute_task : region<execution> {
+    /// Set code region name for regions inheriting from execute_task with the
+    /// following prefix.
+    inline static const std::string tag{"execute_task->"};
+  };
+  struct execute_task_init : execute_task<execute_task_init> {
+    inline static const std::string tag{"init-handles"};
+    inline static const std::string name{
+      execute_task<execute_task_init>::tag + tag};
+    static constexpr detail detail_level = detail::high;
+  };
+  struct execute_task_initargs : execute_task<execute_task_initargs> {
+    inline static const std::string tag{"init-args"};
+    inline static const std::string name{
+      execute_task<execute_task_initargs>::tag + tag};
+    static constexpr detail detail_level = detail::high;
+  };
+  struct execute_task_prolog : execute_task<execute_task_prolog> {
+    inline static const std::string tag{"prolog"};
+    inline static const std::string name{
+      execute_task<execute_task_prolog>::tag + tag};
+    static constexpr detail detail_level = detail::high;
+  };
+  struct execute_task_user : execute_task<execute_task_user> {
+    inline static const std::string tag{"user"};
+    inline static const std::string name{
+      execute_task<execute_task_user>::tag + tag};
+  };
+  struct execute_task_epilog : execute_task<execute_task_epilog> {
+    inline static const std::string tag{"epilog"};
+    inline static const std::string name{
+      execute_task<execute_task_epilog>::tag + tag};
+    static constexpr detail detail_level = detail::high;
+  };
+  struct execute_task_finalize : execute_task<execute_task_finalize> {
+    inline static const std::string tag{"finalize-handles"};
+    inline static const std::string name{
+      execute_task<execute_task_finalize>::tag + tag};
+    static constexpr detail detail_level = detail::high;
+  };
+#endif
   /**
    * Tag beginning of code region with caliper annotation.
    *

--- a/flecsi/utils/array_ref.h
+++ b/flecsi/utils/array_ref.h
@@ -306,18 +306,20 @@ public:
     (--e)->~value_type();
   }
 
+  struct cleanup {
+    vector_ref & v;
+    size_type sz0;
+    bool fail = true;
+    ~cleanup() {
+      if(fail)
+        v.resize(sz0);
+    }
+  };
+
   constexpr void resize(size_type n) {
     reserve(n);
     auto sz = size();
-    struct cleanup {
-      vector_ref & v;
-      size_type sz0;
-      bool fail = true;
-      ~cleanup() {
-        if(fail)
-          v.resize(sz0);
-      }
-    } guard = {*this, sz};
+    cleanup guard = {*this, sz};
 
     for(; sz > n; --sz)
       pop_back();

--- a/flecsi/utils/demangle.cc
+++ b/flecsi/utils/demangle.cc
@@ -18,6 +18,8 @@
 #include <cxxabi.h>
 #endif
 
+#include <flecsi/utils/demangle.h>
+
 namespace flecsi {
 namespace utils {
 

--- a/flecsi/utils/demangle.h
+++ b/flecsi/utils/demangle.h
@@ -13,6 +13,8 @@
                                                                               */
 #pragma once
 
+#include <flecsi/utils/export_definitions.h>
+
 /*! @file */
 
 namespace flecsi {
@@ -26,7 +28,7 @@ namespace utils {
   @ingroup utils
  */
 
-std::string demangle(const char * const name);
+FLECSI_EXPORT std::string demangle(const char * const name);
 
 /*!
   Return the demangled name of the type T.

--- a/flecsi/utils/mpi_type_traits.h
+++ b/flecsi/utils/mpi_type_traits.h
@@ -121,6 +121,8 @@ struct mpi_typetraits_u {
       return MPI_CXX_DOUBLE_COMPLEX;
     else if constexpr(is_same_v<TYPE, complex<long double>>)
       return MPI_CXX_LONG_DOUBLE_COMPLEX;
+
+    // MSVC is confused without the explicit std:: qualification
     else if constexpr(is_same_v<TYPE, std::byte>)
       return MPI_BYTE;
     else

--- a/flecsi/utils/mpi_type_traits.h
+++ b/flecsi/utils/mpi_type_traits.h
@@ -121,7 +121,7 @@ struct mpi_typetraits_u {
       return MPI_CXX_DOUBLE_COMPLEX;
     else if constexpr(is_same_v<TYPE, complex<long double>>)
       return MPI_CXX_LONG_DOUBLE_COMPLEX;
-    else if constexpr(is_same_v<TYPE, byte>)
+    else if constexpr(is_same_v<TYPE, std::byte>)
       return MPI_BYTE;
     else
       return make<Make>();


### PR DESCRIPTION
This separates the changes that are unrelated to HPX from #643 

This patch fixes a set of warnings generated by various compilers:

- integral conversion errors
- possibly empty `if` statements
- some performance warnings
- etc.

This also applies workarounds for problems caused by MSVC:

- min()/max() possibly being defined as macros
- templates are being instantiated too eagerly


